### PR TITLE
Input fastqs directly

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -5,3 +5,8 @@ workflows:
     primaryDescriptorPath: /myco.wdl
     authors:
       - orcid: 0000-0003-4896-1858
+  - name: myco_sra
+    subclass: WDL
+    primaryDescriptorPath: /myco_sra.wdl
+    authors:
+      - orcid: 0000-0003-4896-1858

--- a/README.md
+++ b/README.md
@@ -7,5 +7,17 @@ myco imports almost all of its code from other repos. Please see those specific 
 * Turning VCFs into diff files: [parsevcf](https://github.com/lilymaryam/parsevcf)
 
 
+## Which workflow should I use?
+If you already have a bunch of fastqs: myco.wdl  
+If you want to pull fastqs from SRA or ENA: myco_sra.wdl  
+
+Note that pulling from SRA allows for more data validation than putting in fastqs directly. If using myco.wdl, please make sure your data:
+* is Illumina paired-end data  
+* is grouped per-sample  
+* is actually tuberculosis  
+* len(quality scores) = len(nucleotides) for every line  
+* isn't huge — individual files over `subsample_cutoff` (default: 450 MB) will be downsampled, but keep an eye on the cumulative size of samples which have lots of small reads (ex: SAMEA968096)
+
+
 ## Running myco
 The currently recommended way to run myco is on Terra, a cloud-computing resource which uses Google as its backend. However, it also runs as-is on local machines. See [running_myco.md](/doc/running_myco.md) for instructions.

--- a/myco.wdl
+++ b/myco.wdl
@@ -24,7 +24,9 @@ workflow myco {
 				unsorted_sam = true,
 				reads_files = pulled_fastq,
 				tarball_ref_fasta_and_index = ClockworkRefPrepTB.tar_indexd_dcontm_ref,
-				ref_fasta_filename = "ref.fa"
+				ref_fasta_filename = "ref.fa",
+				subsample_cutoff = 450,
+				subsample_seed = 1965
 		}
 
 		call clckwrk_var_call.variant_call_one_sample_simple as varcall_with_array {

--- a/myco.wdl
+++ b/myco.wdl
@@ -3,8 +3,6 @@ version 1.0
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.0.1/workflows/refprep-TB.wdl" as clockwork_ref_prepWF
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.4.0/tasks/combined_decontamination.wdl" as clckwrk_combonation
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.3.1/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
-import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.3/tasks/pull_fastqs.wdl" as sranwrp_pull
-import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.2/tasks/processing_tasks.wdl" as sranwrp_processing
 import "https://raw.githubusercontent.com/aofarrel/parsevcf/0.99.0/vcf_to_diff.wdl" as diff
 
 workflow myco {

--- a/myco.wdl
+++ b/myco.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.0.1/workflows/refprep-TB.wdl" as clockwork_ref_prepWF
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.3.1/tasks/combined_decontamination.wdl" as clckwrk_combonation
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/add-subsample-to-decontamination/tasks/combined_decontamination.wdl" as clckwrk_combonation
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.3.1/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
 import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.3/tasks/pull_fastqs.wdl" as sranwrp_pull
 import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.2/tasks/processing_tasks.wdl" as sranwrp_processing

--- a/myco.wdl
+++ b/myco.wdl
@@ -12,7 +12,8 @@ workflow myco {
 		Array[Array[File]] paired_fastqs
 		File typical_tb_masked_regions
 		Int min_coverage = 10
-		Boolean tar_fqs = false
+		Int subsample_cutoff = -1
+		Int subsample_seed = 1965
 	}
 
 	call clockwork_ref_prepWF.ClockworkRefPrepTB
@@ -25,8 +26,8 @@ workflow myco {
 				reads_files = pulled_fastq,
 				tarball_ref_fasta_and_index = ClockworkRefPrepTB.tar_indexd_dcontm_ref,
 				ref_fasta_filename = "ref.fa",
-				subsample_cutoff = 450,
-				subsample_seed = 1965
+				subsample_cutoff = subsample_cutoff,
+				subsample_seed = subsample_seed
 		}
 
 		call clckwrk_var_call.variant_call_one_sample_simple as varcall_with_array {

--- a/myco.wdl
+++ b/myco.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.0.1/workflows/refprep-TB.wdl" as clockwork_ref_prepWF
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/add-subsample-to-decontamination/tasks/combined_decontamination.wdl" as clckwrk_combonation
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.4.0/tasks/combined_decontamination.wdl" as clckwrk_combonation
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.3.1/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
 import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.3/tasks/pull_fastqs.wdl" as sranwrp_pull
 import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.2/tasks/processing_tasks.wdl" as sranwrp_processing

--- a/myco.wdl
+++ b/myco.wdl
@@ -9,108 +9,49 @@ import "https://raw.githubusercontent.com/aofarrel/parsevcf/0.99.0/vcf_to_diff.w
 
 workflow myco {
 	input {
-		File biosample_accessions
+		Array[Array[File]] paired_fastqs
 		File typical_tb_masked_regions
 		Int min_coverage = 10
 		Boolean tar_fqs = false
-		Boolean less_scattering = false
 	}
 
 	call clockwork_ref_prepWF.ClockworkRefPrepTB
 
-	call sranwrp_processing.extract_accessions_from_file as get_sample_IDs {
-		input:
-			accessions_file = biosample_accessions
-	}
-
-	scatter(biosample_accession in get_sample_IDs.accessions) {
-		call sranwrp_pull.pull_fq_from_biosample as pull {
-			input:
-				biosample_accession = biosample_accession,
-				tar_outputs = tar_fqs
-		} # output: pull.fastqs OR pull.tarball_fastqs
-		if(length(pull.fastqs)>1) {
-    		Array[File] paired_fastqs=select_all(pull.fastqs)
-  		}
-	}
-
-	call sranwrp_processing.cat_files as cat_reports {
-		input:
-			files = pull.results
-	}
-
-	if(!less_scattering) {
-		Array[Array[File]] pulled_fastqs   = select_all(paired_fastqs)
-		scatter(pulled_fastq in pulled_fastqs) {
-			call clckwrk_combonation.combined_decontamination_single as decontaminate_one_sample {
-				input:
-					unsorted_sam = true,
-					reads_files = pulled_fastq,
-					tarball_ref_fasta_and_index = ClockworkRefPrepTB.tar_indexd_dcontm_ref,
-					ref_fasta_filename = "ref.fa"
-			}
-
-			call clckwrk_var_call.variant_call_one_sample_simple as varcall_with_array {
-				input:
-					ref_dir = ClockworkRefPrepTB.tar_indexd_H37Rv_ref,
-					reads_files = [decontaminate_one_sample.decontaminated_fastq_1, decontaminate_one_sample.decontaminated_fastq_2]
-			} # output: varcall_with_array.vcf_final_call_set, varcall_with_array.mapped_to_ref
-
-		}
-
-		Array[File] minos_vcfs_=select_all(varcall_with_array.vcf_final_call_set)
-		Array[File] bams_to_ref_=select_all(varcall_with_array.mapped_to_ref)
-
-
-		scatter(vcfs_and_bams in zip(bams_to_ref_, minos_vcfs_)) {
-			call diff.make_mask_and_diff as make_mask_and_diff_ {
-				input:
-					bam = vcfs_and_bams.left,
-					vcf = vcfs_and_bams.right,
-					min_coverage = min_coverage,
-					tbmf = typical_tb_masked_regions
-			}
-		}
-	}
-
-	if(less_scattering) {
-		Array[File] tarball_paired_fastqs=select_all(pull.tarball_fastqs)
-		call clckwrk_combonation.combined_decontamination_multiple as decontaminate_many_samples {
+	Array[Array[File]] pulled_fastqs   = select_all(paired_fastqs)
+	scatter(pulled_fastq in pulled_fastqs) {
+		call clckwrk_combonation.combined_decontamination_single as decontaminate_one_sample {
 			input:
 				unsorted_sam = true,
-				tarballs_of_read_files = tarball_paired_fastqs,
+				reads_files = pulled_fastq,
 				tarball_ref_fasta_and_index = ClockworkRefPrepTB.tar_indexd_dcontm_ref,
 				ref_fasta_filename = "ref.fa"
-		} # output: decontaminate_many_samples.tarballs_of_decontaminated_reads
-		
-		scatter(one_sample in decontaminate_many_samples.tarballs_of_decontaminated_reads) {
-			call clckwrk_var_call.variant_call_one_sample_verbose as varcall_with_tarballs {
-				input:
-					ref_dir = ClockworkRefPrepTB.tar_indexd_H37Rv_ref,
-					tarball_of_reads_files = one_sample
-			} # output: varcall_with_tarballs.vcf_final_call_set, varcall_with_tarballs.mapped_to_ref
 		}
 
-		Array[File] minos_vcfs=select_all(varcall_with_tarballs.vcf_final_call_set)
-		Array[File] bams_to_ref=select_all(varcall_with_tarballs.mapped_to_ref)
+		call clckwrk_var_call.variant_call_one_sample_simple as varcall_with_array {
+			input:
+				ref_dir = ClockworkRefPrepTB.tar_indexd_H37Rv_ref,
+				reads_files = [decontaminate_one_sample.decontaminated_fastq_1, decontaminate_one_sample.decontaminated_fastq_2]
+		} # output: varcall_with_array.vcf_final_call_set, varcall_with_array.mapped_to_ref
+
+	}
+
+	Array[File] minos_vcfs_=select_all(varcall_with_array.vcf_final_call_set)
+	Array[File] bams_to_ref_=select_all(varcall_with_array.mapped_to_ref)
 
 
-		scatter(vcfs_and_bams in zip(bams_to_ref, minos_vcfs)) {
-			call diff.make_mask_and_diff as make_mask_and_diff {
-				input:
-					bam = vcfs_and_bams.left,
-					vcf = vcfs_and_bams.right,
-					min_coverage = min_coverage,
-					tbmf = typical_tb_masked_regions
-			}
+	scatter(vcfs_and_bams in zip(bams_to_ref_, minos_vcfs_)) {
+		call diff.make_mask_and_diff as make_mask_and_diff_ {
+			input:
+				bam = vcfs_and_bams.left,
+				vcf = vcfs_and_bams.right,
+				min_coverage = min_coverage,
+				tbmf = typical_tb_masked_regions
 		}
-
 	}
 
 	output {
-		Array[File] minos = select_first([minos_vcfs, minos_vcfs_])
-		Array[File] masks = select_first([make_mask_and_diff.mask_file, make_mask_and_diff_.mask_file])
-		Array[File] diffs = select_first([make_mask_and_diff.diff, make_mask_and_diff_.diff])
-		File pull_report = cat_reports.outfile
+		Array[File] minos = minos_vcfs_
+		Array[File] masks = make_mask_and_diff_.mask_file
+		Array[File] diffs = make_mask_and_diff_.diff
 	}
 }

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -1,0 +1,116 @@
+version 1.0
+
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.0.1/workflows/refprep-TB.wdl" as clockwork_ref_prepWF
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.3.1/tasks/combined_decontamination.wdl" as clckwrk_combonation
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.3.1/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
+import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.3/tasks/pull_fastqs.wdl" as sranwrp_pull
+import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.2/tasks/processing_tasks.wdl" as sranwrp_processing
+import "https://raw.githubusercontent.com/aofarrel/parsevcf/0.99.0/vcf_to_diff.wdl" as diff
+
+workflow myco {
+	input {
+		File biosample_accessions
+		File typical_tb_masked_regions
+		Int min_coverage = 10
+		Boolean tar_fqs = false
+		Boolean less_scattering = false
+	}
+
+	call clockwork_ref_prepWF.ClockworkRefPrepTB
+
+	call sranwrp_processing.extract_accessions_from_file as get_sample_IDs {
+		input:
+			accessions_file = biosample_accessions
+	}
+
+	scatter(biosample_accession in get_sample_IDs.accessions) {
+		call sranwrp_pull.pull_fq_from_biosample as pull {
+			input:
+				biosample_accession = biosample_accession,
+				tar_outputs = tar_fqs
+		} # output: pull.fastqs OR pull.tarball_fastqs
+		if(length(pull.fastqs)>1) {
+    		Array[File] paired_fastqs=select_all(pull.fastqs)
+  		}
+	}
+
+	call sranwrp_processing.cat_files as cat_reports {
+		input:
+			files = pull.results
+	}
+
+	if(!less_scattering) {
+		Array[Array[File]] pulled_fastqs   = select_all(paired_fastqs)
+		scatter(pulled_fastq in pulled_fastqs) {
+			call clckwrk_combonation.combined_decontamination_single as decontaminate_one_sample {
+				input:
+					unsorted_sam = true,
+					reads_files = pulled_fastq,
+					tarball_ref_fasta_and_index = ClockworkRefPrepTB.tar_indexd_dcontm_ref,
+					ref_fasta_filename = "ref.fa"
+			}
+
+			call clckwrk_var_call.variant_call_one_sample_simple as varcall_with_array {
+				input:
+					ref_dir = ClockworkRefPrepTB.tar_indexd_H37Rv_ref,
+					reads_files = [decontaminate_one_sample.decontaminated_fastq_1, decontaminate_one_sample.decontaminated_fastq_2]
+			} # output: varcall_with_array.vcf_final_call_set, varcall_with_array.mapped_to_ref
+
+		}
+
+		Array[File] minos_vcfs_=select_all(varcall_with_array.vcf_final_call_set)
+		Array[File] bams_to_ref_=select_all(varcall_with_array.mapped_to_ref)
+
+
+		scatter(vcfs_and_bams in zip(bams_to_ref_, minos_vcfs_)) {
+			call diff.make_mask_and_diff as make_mask_and_diff_ {
+				input:
+					bam = vcfs_and_bams.left,
+					vcf = vcfs_and_bams.right,
+					min_coverage = min_coverage,
+					tbmf = typical_tb_masked_regions
+			}
+		}
+	}
+
+	if(less_scattering) {
+		Array[File] tarball_paired_fastqs=select_all(pull.tarball_fastqs)
+		call clckwrk_combonation.combined_decontamination_multiple as decontaminate_many_samples {
+			input:
+				unsorted_sam = true,
+				tarballs_of_read_files = tarball_paired_fastqs,
+				tarball_ref_fasta_and_index = ClockworkRefPrepTB.tar_indexd_dcontm_ref,
+				ref_fasta_filename = "ref.fa"
+		} # output: decontaminate_many_samples.tarballs_of_decontaminated_reads
+		
+		scatter(one_sample in decontaminate_many_samples.tarballs_of_decontaminated_reads) {
+			call clckwrk_var_call.variant_call_one_sample_verbose as varcall_with_tarballs {
+				input:
+					ref_dir = ClockworkRefPrepTB.tar_indexd_H37Rv_ref,
+					tarball_of_reads_files = one_sample
+			} # output: varcall_with_tarballs.vcf_final_call_set, varcall_with_tarballs.mapped_to_ref
+		}
+
+		Array[File] minos_vcfs=select_all(varcall_with_tarballs.vcf_final_call_set)
+		Array[File] bams_to_ref=select_all(varcall_with_tarballs.mapped_to_ref)
+
+
+		scatter(vcfs_and_bams in zip(bams_to_ref, minos_vcfs)) {
+			call diff.make_mask_and_diff as make_mask_and_diff {
+				input:
+					bam = vcfs_and_bams.left,
+					vcf = vcfs_and_bams.right,
+					min_coverage = min_coverage,
+					tbmf = typical_tb_masked_regions
+			}
+		}
+
+	}
+
+	output {
+		Array[File] minos = select_first([minos_vcfs, minos_vcfs_])
+		Array[File] masks = select_first([make_mask_and_diff.mask_file, make_mask_and_diff_.mask_file])
+		Array[File] diffs = select_first([make_mask_and_diff.diff, make_mask_and_diff_.diff])
+		File pull_report = cat_reports.outfile
+	}
+}


### PR DESCRIPTION
Reads can now be input into the pipeline directly instead of being pulled from SRA/ENA. This uses a newer version of clockwork-wdl's combined decontamination task to allow for reads to immediately be downsampled. This is needed because it now operates without SRANWRP's pull task.

Tested and passes on Terra.