### PR TITLE
Overhaul input variables and names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cromwell-input/*
 _LAST
 raw.txt
 .vscode/settings.json
+doc/FAQs.md

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ cromwell-input/*
 _LAST
 raw.txt
 .vscode/settings.json
-doc/FAQs.md

--- a/doc/FAQs.md
+++ b/doc/FAQs.md
@@ -1,0 +1,44 @@
+# FAQs
+
+## General
+### Where do samples get dropped?
+|   | pipeline                         | task                     | situation                                                                                                                       | can this filter be disabled?            | can be made a fatal error instead of a silent filter? |
+|---|----------------------------------|--------------------------|---------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------|-------------------------------------------------------|
+|   | myco_sra                         | get_sample_IDs           | BioSample accession appears to be invalid                                                                                       | no                                      | no                                                    |
+|   | myco_sra                         | pull                     | ALL of a BioSample's run accessions fail prefetch and/or fasterq-dump                                                           | no                                      | yes, via `pull.fail_on_invalid`                       |
+|   | myco_sra                         | pull                     | ≥1 of a BioSample's run accessions fail prefetch and/or fasterq-dump                                                            | yes, disabled by default                | yes, via `pull.fail_on_invalid`                       |
+|   | myco_sra                         | pull                     | ALL of a BioSample's run accessions have only one fastq                                                                         | no                                      | yes, via `pull.fail_on_invalid`                       |
+|   | myco_sra                         | pull                     | ≥1 of a BioSample's run accessions have only one fastq                                                                          | yes, disabled by default                | yes, via `pull.fail_on_invalid`                       |
+|   | myco_sra, myco_raw               | decontam_each_sample     | sample takes ≥ `timeout_decontam_part1` minutes to map to the decontamination reference via `clockwork map_reads`               | yes, via `timeout_decontam_part1` = 0   | yes, via `variant_call_each_sample.crash_on_timeout`  |
+|   | myco_sra, myco_raw               | decontam_each_sample     | sample takes ≥ `timeout_decontam_part2` minutes to map to the decontamination reference via `clockwork remove_contam`           | yes, via `timeout_decontam_part2` = 0   | yes, via `variant_call_each_sample.crash_on_timeout`  |
+|   | myco_sra, myco_raw, myco_cleaned | variant_call_each_sample | sample takes ≥ `timeout_variant_caller` minutes to map to the decontamination reference via `clockwork variant_call_one_sample` | yes, via `timeout_variant_caller` = 0   | yes, via `variant_call_each_sample.crash_on_timeout`  |
+|   | myco_sra, myco_raw, myco_cleaned | variant_call_each_sample | non-timeout error in `clockwork variant_call_one_sample`                                                                        | no                                      | yes, via `variant_call_each_sample.crash_on_error`    |
+|   | myco_sra, myco_raw, myco_cleaned | trees.cat_diff_files     | porportion of low coverage sites in a sample's diff file ≥ `max_low_coverage_sites`                                             | yes, via `max_low_coverage_sites` = 1.0 | no                                                    |
+
+
+Miscellanous notes:
+* SRA data failing prefetch or fasterq-dump (from sra-tools) usually means that data is corrupt. If you find ENA data on SRA that looks it ought not be corrupt, but can't be downloaded, try ENABrowserTools or [my WDlization of it](https://github.com/aofarrel/enaBrowserTools-wdl)
+* These timers apply to the same WDL task but are for different processes within that task -- `timeout_decontam_part1` is 20 and `timeout_decontam_part1` is 15, and a sample spends 19 minutes mapping plus another 14 minutes finishing the decontamination process, it will *not* be filtered out.
+* clockwork's variant caller failing could mean it ran out of memory or was passed bad data, so the pipeline doesn't crash when this happens unless `variant_call_each_sample.crash_on_error` is set to true. Erroring out in the decontamination step is more indicative a serious issue, so a non-timeout error in that step will crash the pipeline.
+
+### Where does data get filtered?
+* If a FASTQ is above `subsample_cutoff` MB, it will get downsampled by seqtk
+* When diff files are created, two types of regions will be masked:
+  * regions that tend to be frequently masked when dealing with TB are masked (note: upstream outputs such as the VCF do not get masked)
+  * regions which have called a variant but that variant has less coverage than 
+
+### Why are there so many places where samples get dropped?
+Myco was originally designed with the goal of analyzing as much TB SRA data as we could relatively quickly and cheaply. About 94% of MTBC BioSamples which are tagged as containing paired Illumina data pass myco_sra default's filters. Roughly 3% of that data is either completely invalid (fails fasterq-dump due to a database migration error that happended years ago, length of quality score doesn't match length of nucleotide strings, etc) or can't be used by clockwork (not actually paired Illumina reads, etc). The remainder of what gets filtered out seems to be extremely heavily contaminated and/or low overall coverage. As such, we're reasonably confident that myco_sra's default filters are a good tradeoff for the realities of SRA's data. Of course, you might want to cast a wider net than we did, or you might not be using SRA data at all, so all of these filters except for this-will-100%-break-the-pipeline-if-you-let-this-through ones can be configured.
+
+
+### What if I want to use a different reference genome?
+This isn't officially supported due to TBProfiler, UShER, and clockwork each needing specific reference genomes:
+* TBProfiler's reference genome must be *exactly* the same as the one you called variants upon, if you're running TBProfiler on bams
+* UShER has limitations on how long a chromosome's name can be
+* clockwork's decontamination is designed with their specific decontamination reference in mind
+That being said, old versions of myco used clockwork reference prepare to prepare the TB genome, and you could hack that passing-reference-genomes-around functionality to use your own custom reference genomes if you're confident. The latest version of myco that used clockwork reference prepare was [4.1.3](https://github.com/aofarrel/myco/releases/tag/4.1.3), so that's a good place to start.
+
+
+## Common warnings/errors
+### trees/tree_nine/cat_diff_files fails with `Disk strings should be of the format 'local-disk SIZE TYPE' or '/mount/point SIZE TYPE' but got: 'local-disk 0 SSD'`
+This means none of your samples made it to the phylogenetic tree building task. See "Where do samples get dropped?" for more information.

--- a/doc/inputs.md
+++ b/doc/inputs.md
@@ -43,12 +43,12 @@ myco_cleaned expects that the FASTQs you are putting into have already been clea
   
 | name | type | default | description |  
 |:---:|:---:|:---:|:---:|  
-| bad_data_threshold | Float  | 0.05 | If a diff file has higher than this percent (0.5 = 50%) bad data, do not include it in the tree |  
 | decorate_tree | Boolean  | false | Should usher, taxonium, and NextStrain trees be generated? Requires input_tree and ref_genome |  
 | fastqc_on_timeout | Boolean  | false | If true, fastqc one read from a sample when decontamination or variant calling times out |  
 | force_diff | Boolean  | false | If true and if decorate_tree is false, generate diff files. (Diff files will always be created if decorate_tree is true.) |  
 | input_tree | File? |  | Base tree to use if decorate_tree = true |  
-| min_coverage | Int  | 10 | Positions with coverage below this value will be masked in diff files |  
+| max_low_coverage_sites | Float  | 0.05 | If a diff file has higher than this fraction of low coverage data, do not include it in the tree -- ex: 0.02 will remove any samples where 20% or more of their calls are low coverage as defined by min_coverage_per_site |  
+| min_coverage_per_site | Int  | 10 | Positions with coverage below this value will be masked in diff files and count against max_low_coverage_sites |  
 | ref_genome_for_tree_building | File? |  | Ref genome for building trees -- must have ONLY '>NC_000962.3' on its first line |  
 | subsample_cutoff | Int  | 450 | If a fastq file is larger than than size in MB, subsample it with seqtk (set to -1 to disable) |  
 | subsample_seed | Int  | 1965 | Seed used for subsampling with seqtk |  

--- a/doc/inputs.md
+++ b/doc/inputs.md
@@ -47,8 +47,9 @@ myco_cleaned expects that the FASTQs you are putting into have already been clea
 | fastqc_on_timeout | Boolean  | false | If true, fastqc one read from a sample when decontamination or variant calling times out |  
 | force_diff | Boolean  | false | If true and if decorate_tree is false, generate diff files. (Diff files will always be created if decorate_tree is true.) |  
 | input_tree | File? |  | Base tree to use if decorate_tree = true |  
-| max_low_coverage_sites | Float  | 0.05 | If a diff file has higher than this fraction of low coverage data, do not include it in the tree -- ex: 0.02 will remove any samples where 20% or more of their calls are low coverage as defined by min_coverage_per_site |  
-| min_coverage_per_site | Int  | 10 | Positions with coverage below this value will be masked in diff files and count against max_low_coverage_sites |  
+| max_low_coverage_sites | Float  | 0.05 | If a diff file has higher than this percent (0.5 = 50%) bad data, do not include it in the tree |  
+| min_coverage_per_site | Int  | 10 | Positions with coverage below this value will be masked in diff files |  
+| ref_genome_for_tree_building | File |  | Ref genome for building trees -- must have ONLY '>NC_000962.3' on its first line |  
 | ref_genome_for_tree_building | File? |  | Ref genome for building trees -- must have ONLY '>NC_000962.3' on its first line |  
 | subsample_cutoff | Int  | 450 | If a fastq file is larger than than size in MB, subsample it with seqtk (set to -1 to disable) |  
 | subsample_seed | Int  | 1965 | Seed used for subsampling with seqtk |  
@@ -65,28 +66,26 @@ If you are on a backend that does not support call cacheing, you can use the 'bl
   
 | task | name | type | default | description |  
 |:---:|:---:|:---:|:---:|:---:|  
-| ClockworkRefPrepTB | bluepeter__tar_indexd_H37Rv_ref | File? |  |  |  
 | ClockworkRefPrepTB | bluepeter__tar_indexd_dcontm_ref | File? |  |  |  
 | ClockworkRefPrepTB | bluepeter__tar_tb_ref_raw | File? |  |  |  
-| cat_reports | out | String  | \'pull_reports.txt\' | Override default output file name with this string |  
+| decontam_each_sample | contam_out_1 | String? |  | Override default output file name with this string |  
+| decontam_each_sample | contam_out_2 | String? |  | Override default output file name with this string |  
+| decontam_each_sample | counts_out | String? |  | Override default output file name with this string |  
+| decontam_each_sample | crash_on_timeout | Boolean  | false | If this task times out, should it stop the whole pipeline (true), or should we just discard this sample and move on (false)? |  
+| decontam_each_sample | done_file | String? |  | Override default output file name with this string |  
+| decontam_each_sample | no_match_out_1 | String? |  | Override default output file name with this string |  
+| decontam_each_sample | no_match_out_2 | String? |  | Override default output file name with this string |  
+| decontam_each_sample | subsample_cutoff | Int  | -1 | If a FASTQ file is larger than than size in MB, subsample it with seqtk (set to -1 to disable) |  
+| decontam_each_sample | subsample_seed | Int  | 1965 | Seed used for subsampling with seqtk |  
+| decontam_each_sample | threads | Int? |  | Try to use this many threads for decontamination. Note that actual number of threads also relies on your hardware. |  
+| decontam_each_sample | verbose | Boolean  | true |  |  
 | make_mask_and_diff | histograms | Boolean  | false | Should coverage histograms be output? |  
-| per_sample_decontam | contam_out_1 | String? |  | Override default output file name with this string |  
-| per_sample_decontam | contam_out_2 | String? |  | Override default output file name with this string |  
-| per_sample_decontam | counts_out | String? |  | Override default output file name with this string |  
-| per_sample_decontam | crash_on_timeout | Boolean  | false | If this task times out, should it stop the whole pipeline (true), or should we just discard this sample and move on (false)? |  
-| per_sample_decontam | done_file | String? |  | Override default output file name with this string |  
-| per_sample_decontam | no_match_out_1 | String? |  | Override default output file name with this string |  
-| per_sample_decontam | no_match_out_2 | String? |  | Override default output file name with this string |  
-| per_sample_decontam | subsample_cutoff | Int  | -1 | If a FASTQ file is larger than than size in MB, subsample it with seqtk (set to -1 to disable) |  
-| per_sample_decontam | subsample_seed | Int  | 1965 | Seed used for subsampling with seqtk |  
-| per_sample_decontam | threads | Int? |  | Try to use this many threads for decontamination. Note that actual number of threads also relies on your hardware. |  
-| per_sample_decontam | verbose | Boolean  | true |  |  
 | trees | make_nextstrain_subtrees | Boolean  | true |  |  
 | trees | outfile | String? |  | Override default output file name with this string |  
-| varcall_with_array | crash_on_error | Boolean  | false | If this task, should it stop the whole pipeline (true), or should we just discard this sample and move on (false)? Note that errors that crash the VM (such as running out of space on a GCP instance) will stop the whole pipeline regardless of this setting. |  
-| varcall_with_array | crash_on_timeout | Boolean  | false | If this task times out, should it stop the whole pipeline (true), or should we just discard this sample and move on (false)? |  
-| varcall_with_array | debug | Boolean  | false | Do not clean up any files and be verbose |  
-| varcall_with_array | mem_height | Int? |  | cortex mem_height option. Must match what was used when reference_prepare was run (in other words do not set this variable unless you are also adjusting the reference preparation task) |  
+| variant_call_each_sample | crash_on_error | Boolean  | false | If this task, should it stop the whole pipeline (true), or should we just discard this sample and move on (false)? Note that errors that crash the VM (such as running out of space on a GCP instance) will stop the whole pipeline regardless of this setting. |  
+| variant_call_each_sample | crash_on_timeout | Boolean  | false | If this task times out, should it stop the whole pipeline (true), or should we just discard this sample and move on (false)? |  
+| variant_call_each_sample | debug | Boolean  | false | Do not clean up any files and be verbose |  
+| variant_call_each_sample | mem_height | Int? |  | cortex mem_height option. Must match what was used when reference_prepare was run (in other words do not set this variable unless you are also adjusting the reference preparation task) |  
   
   
 ### Runtime attributes  
@@ -94,24 +93,31 @@ These variables adjust runtime attributes, which includes hardware settings. See
   
 | task | name | type | default | description |  
 |:---:|:---:|:---:|:---:|:---:|  
-| cat_reports | disk_size | Int  | 10 | Disk size, in GB. Note that since cannot auto-scale as it cannot anticipate the size of reads from SRA. |  
+| cat_resistance | disk_size | Int  | 10 | Disk size, in GB. Note that since cannot auto-scale as it cannot anticipate the size of reads from SRA. |  
+| cat_strains | disk_size | Int  | 10 | Disk size, in GB. Note that since cannot auto-scale as it cannot anticipate the size of reads from SRA. |  
+| decontam_each_sample | addldisk | Int  | 100 | Additional disk size, in GB, on top of auto-scaling disk size. |  
+| decontam_each_sample | cpu | Int  | 8 | Number of CPUs (cores) to request from GCP. |  
+| decontam_each_sample | memory | Int  | 16 | Amount of memory, in GB, to request from GCP. |  
+| decontam_each_sample | preempt | Int  | 1 | How many times should this task be attempted on a preemptible instance before running on a non-preemptible instance? |  
+| decontam_each_sample | ssd | Boolean  | true | If true, use SSDs for this task instead of HDDs |  
 | get_sample_IDs | preempt | Int  | 1 | How many times should this task be attempted on a preemptible instance before running on a non-preemptible instance? |  
 | make_mask_and_diff | addldisk | Int  | 10 | Additional disk size, in GB, on top of auto-scaling disk size. |  
 | make_mask_and_diff | cpu | Int  | 8 | Number of CPUs (cores) to request from GCP. |  
 | make_mask_and_diff | memory | Int  | 16 | Amount of memory, in GB, to request from GCP. |  
 | make_mask_and_diff | preempt | Int  | 1 | How many times should this task be attempted on a preemptible instance before running on a non-preemptible instance? |  
+| make_mask_and_diff | preempt | Int  | 1 | How many times should this task be attempted on a preemptible instance before running on a non-preemptible instance? |  
 | make_mask_and_diff | retries | Int  | 1 | How many times should we retry this task if it fails after it exhausts all uses of preemptibles? |  
-| per_sample_decontam | addldisk | Int  | 100 | Additional disk size, in GB, on top of auto-scaling disk size. |  
-| per_sample_decontam | cpu | Int  | 8 | Number of CPUs (cores) to request from GCP. |  
-| per_sample_decontam | memory | Int  | 16 | Amount of memory, in GB, to request from GCP. |  
-| per_sample_decontam | preempt | Int  | 1 | How many times should this task be attempted on a preemptible instance before running on a non-preemptible instance? |  
-| per_sample_decontam | ssd | Boolean  | true | If true, use SSDs for this task instead of HDDs |  
+| merge_reports | disk_size | Int  | 10 | Disk size, in GB. Note that since cannot auto-scale as it cannot anticipate the size of reads from SRA. |  
+| profile | cpu | Int  | 2 | Number of CPUs (cores) to request from GCP. |  
+| profile | memory | Int  | 4 | Amount of memory, in GB, to request from GCP. |  
+| profile | preempt | Int  | 1 | How many times should this task be attempted on a preemptible instance before running on a non-preemptible instance? |  
+| profile | ssd | Boolean  | false | If true, use SSDs for this task instead of HDDs |  
 | pull | disk_size | Int  | 100 | Disk size, in GB. Note that since cannot auto-scale as it cannot anticipate the size of reads from SRA. |  
 | pull | preempt | Int  | 1 | How many times should this task be attempted on a preemptible instance before running on a non-preemptible instance? |  
-| varcall_with_array | addldisk | Int  | 100 | Additional disk size, in GB, on top of auto-scaling disk size. |  
-| varcall_with_array | cpu | Int  | 16 | Number of CPUs (cores) to request from GCP. |  
-| varcall_with_array | memory | Int  | 32 | Amount of memory, in GB, to request from GCP. |  
-| varcall_with_array | preempt | Int  | 1 | How many times should this task be attempted on a preemptible instance before running on a non-preemptible instance? |  
-| varcall_with_array | retries | Int  | 1 | How many times should we retry this task if it fails after it exhausts all uses of preemptibles? |  
-| varcall_with_array | ssd | Boolean  | true | If true, use SSDs for this task instead of HDDs |  
+| variant_call_each_sample | addldisk | Int  | 100 | Additional disk size, in GB, on top of auto-scaling disk size. |  
+| variant_call_each_sample | cpu | Int  | 16 | Number of CPUs (cores) to request from GCP. |  
+| variant_call_each_sample | memory | Int  | 32 | Amount of memory, in GB, to request from GCP. |  
+| variant_call_each_sample | preempt | Int  | 1 | How many times should this task be attempted on a preemptible instance before running on a non-preemptible instance? |  
+| variant_call_each_sample | retries | Int  | 1 | How many times should we retry this task if it fails after it exhausts all uses of preemptibles? |  
+| variant_call_each_sample | ssd | Boolean  | true | If true, use SSDs for this task instead of HDDs |  
   

--- a/inputs/myco_sra_local.json
+++ b/inputs/myco_sra_local.json
@@ -2,7 +2,7 @@
   "myco.biosample_accessions": "inputs/multi_sample/3_samples.txt",
   "myco.decorate_tree": true,
   "myco.input_tree": "inputs/trees/alldiffs_mask2ref.L.fixed.pb",
-  "myco.min_coverage": 10,
+  "myco.min_coverage_per_site": 10,
   "myco.ref_genome_for_tree_building": "inputs/ref/tb_seq.fasta",
   "myco.typical_tb_masked_regions": "inputs/masks/R00000039_repregions.bed"
 }

--- a/inputs/myco_sra_terra.json
+++ b/inputs/myco_sra_terra.json
@@ -2,7 +2,7 @@
   "myco.biosample_accessions": "gs://topmed_workflow_testing/tb/sra/20_samples.txt",
   "myco.decorate_tree": true,
   "myco.ref_genome_for_tree_building": "gs://topmed_workflow_testing/tb/alldiffs_mask2ref.L.fixed.pb",
-  "myco.min_coverage": 10,
+  "myco.min_coverage_per_site": 10,
   "myco.ref_genome": "gs://topmed_workflow_testing/tb/tb_seq.fasta",
   "myco.typical_tb_masked_regions": "gs://topmed_workflow_testing/tb/R00000039_repregions.bed"
 }

--- a/myco_cleaned.wdl
+++ b/myco_cleaned.wdl
@@ -4,6 +4,7 @@ import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.8.0/tasks/var
 import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.6/tree_nine.wdl" as build_treesWF
 import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.7/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/fastqc-wdl/main/fastqc.wdl" as fastqc
+#import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.2.0/tbprofiler_tasks.wdl" as profiler
 
 workflow myco {
 	input {

--- a/myco_cleaned.wdl
+++ b/myco_cleaned.wdl
@@ -4,7 +4,7 @@ import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.8.0/tasks/var
 import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.6/tree_nine.wdl" as build_treesWF
 import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.7/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/fastqc-wdl/main/fastqc.wdl" as fastqc
-#import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.2.0/tbprofiler_tasks.wdl" as profiler
+#import "https://raw.githubusercontent.com/aofarrel/tb_profiler/main/tbprofiler_tasks.wdl" as profiler
 
 workflow myco {
 	input {

--- a/myco_cleaned.wdl
+++ b/myco_cleaned.wdl
@@ -4,7 +4,7 @@ import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.8.0/tasks/var
 import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.6/tree_nine.wdl" as build_treesWF
 import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.7/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/fastqc-wdl/main/fastqc.wdl" as fastqc
-#import "https://raw.githubusercontent.com/aofarrel/tb_profiler/main/tbprofiler_tasks.wdl" as profiler
+#import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.2.1/tbprofiler_tasks.wdl" as profiler
 
 workflow myco {
 	input {

--- a/myco_cleaned.wdl
+++ b/myco_cleaned.wdl
@@ -10,23 +10,23 @@ workflow myco {
 		Array[Array[File]] paired_decontaminated_fastq_sets
 		File typical_tb_masked_regions
 
-		Float   bad_data_threshold = 0.05
 		Boolean decorate_tree      = false
 		Boolean fastqc_on_timeout  = false
 		Boolean force_diff         = false
 		File?   input_tree
-		Int     min_coverage = 10
+		Float   max_low_coverage_sites = 0.05
+		Int     min_coverage_per_site = 10
 		File?   ref_genome_for_tree_building
 		Int     timeout_variant_caller =  120
 	}
 
 	parameter_meta {
-		bad_data_threshold: "If a diff file has higher than this percent (0.5 = 50%) bad data, do not include it in the tree"
+		max_low_coverage_sites: "If a diff file has higher than this percent (0.5 = 50%) bad data, do not include it in the tree"
 		decorate_tree: "Should usher, taxonium, and NextStrain trees be generated? Requires input_tree and ref_genome"
 		fastqc_on_timeout: "If true, fastqc one read from a sample when decontamination or variant calling times out"
 		force_diff: "If true and if decorate_tree is false, generate diff files. (Diff files will always be created if decorate_tree is true.)"
 		input_tree: "Base tree to use if decorate_tree = true"
-		min_coverage: "Positions with coverage below this value will be masked in diff files"
+		min_coverage_per_site: "Positions with coverage below this value will be masked in diff files"
 		paired_decontaminated_fastq_sets: "Nested array of decontaminated and merged fastq pairs. Each inner array represents one sample; each sample needs precisely one forward read and one reverse read."
 		ref_genome_for_tree_building: "Ref genome for building trees -- must have ONLY `>NC_000962.3` on its first line"
 		subsample_cutoff: "If a fastq file is larger than than size in MB, subsample it with seqtk (set to -1 to disable)"
@@ -78,7 +78,7 @@ workflow myco {
 			input:
 				bam = vcfs_and_bams.left,
 				vcf = vcfs_and_bams.right,
-				min_coverage = min_coverage,
+				min_coverage_per_site = min_coverage_per_site,
 				tbmf = typical_tb_masked_regions,
 				diffs = create_diff_files
 		}
@@ -95,7 +95,7 @@ workflow myco {
 				input_mutation_annotated_tree = input_tree,
 				ref = ref_genome_for_tree_building,
 				coverage_reports = coerced_reports,
-				bad_data_threshold = bad_data_threshold
+				max_low_coverage_sites = max_low_coverage_sites
 		}
 	}
 

--- a/myco_cleaned.wdl
+++ b/myco_cleaned.wdl
@@ -1,8 +1,8 @@
 version 1.0
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.8.0/workflows/refprep-TB.wdl" as clockwork_ref_prepWF
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.8.0/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
-import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.5/tree_nine.wdl" as build_treesWF
-import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.4/vcf_to_diff.wdl" as diff
+import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.6/tree_nine.wdl" as build_treesWF
+import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.6/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/fastqc-wdl/main/fastqc.wdl" as fastqc
 
 workflow myco {
@@ -49,7 +49,7 @@ workflow myco {
     call clockwork_ref_prepWF.ClockworkRefPrepTB
 
 	scatter(paired_fastqs in paired_decontaminated_fastq_sets) {
-			call clckwrk_var_call.variant_call_one_sample_simple as varcall_with_array {
+			call clckwrk_var_call.variant_call_one_sample_simple as variant_call_each_sample {
 				input:
 					ref_dir = ClockworkRefPrepTB.tar_indexd_H37Rv_ref,
 					reads_files = paired_fastqs,
@@ -60,8 +60,8 @@ workflow myco {
 	if(fastqc_on_timeout) {
 		# Note: This might be problematic in some situations -- may need to make this look like myco_sra
 		# But until then, I'm going to stick with this simpler implementation
-		if(length(varcall_with_array.check_this_fastq)>1) {
-			Array[File] bad_fastqs_varcallr = select_all(varcall_with_array.check_this_fastq)
+		if(length(variant_call_each_sample.check_this_fastq)>1) {
+			Array[File] bad_fastqs_varcallr = select_all(variant_call_each_sample.check_this_fastq)
 		}
 		call fastqc.FastqcWF {
 			input:
@@ -69,8 +69,8 @@ workflow myco {
 		}
 	}
 
-	Array[File] minos_vcfs=select_all(varcall_with_array.vcf_final_call_set)
-	Array[File] bams_to_ref=select_all(varcall_with_array.mapped_to_ref)
+	Array[File] minos_vcfs=select_all(variant_call_each_sample.vcf_final_call_set)
+	Array[File] bams_to_ref=select_all(variant_call_each_sample.mapped_to_ref)
 
 
 	scatter(vcfs_and_bams in zip(bams_to_ref, minos_vcfs)) {

--- a/myco_cleaned.wdl
+++ b/myco_cleaned.wdl
@@ -2,7 +2,7 @@ version 1.0
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.8.0/workflows/refprep-TB.wdl" as clockwork_ref_prepWF
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.8.0/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
 import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.6/tree_nine.wdl" as build_treesWF
-import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.6/vcf_to_diff.wdl" as diff
+import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.7/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/fastqc-wdl/main/fastqc.wdl" as fastqc
 
 workflow myco {

--- a/myco_raw.wdl
+++ b/myco_raw.wdl
@@ -4,7 +4,7 @@ import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.8.0/workflows
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.8.0/tasks/combined_decontamination.wdl" as clckwrk_combonation
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.8.0/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
 import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.6/tree_nine.wdl" as build_treesWF
-import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.6/vcf_to_diff.wdl" as diff
+import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.7/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/fastqc-wdl/main/fastqc.wdl" as fastqc
 
 workflow myco {

--- a/myco_raw.wdl
+++ b/myco_raw.wdl
@@ -6,7 +6,7 @@ import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.11/tasks/process
 import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.6/tree_nine.wdl" as build_treesWF
 import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.7/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/fastqc-wdl/main/fastqc.wdl" as fastqc
-import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.2.0/tbprofiler_tasks.wdl" as profiler
+import "https://raw.githubusercontent.com/aofarrel/tb_profiler/main/tbprofiler_tasks.wdl" as profiler
 
 workflow myco {
 	input {

--- a/myco_raw.wdl
+++ b/myco_raw.wdl
@@ -12,12 +12,12 @@ workflow myco {
 		Array[Array[File]] paired_fastq_sets
 		File typical_tb_masked_regions
 
-		Float   bad_data_threshold = 0.05
 		Boolean decorate_tree      = false
 		Boolean fastqc_on_timeout  = false
 		Boolean force_diff         = false
 		File?   input_tree
-		Int     min_coverage = 10
+		Float   max_low_coverage_sites = 0.05
+		Int     min_coverage_per_site = 10
 		File?   ref_genome_for_tree_building
 		Int     subsample_cutoff       =  450
 		Int     subsample_seed         = 1965
@@ -27,12 +27,12 @@ workflow myco {
 	}
 
 	parameter_meta {
-		bad_data_threshold: "If a diff file has higher than this percent (0.5 = 50%) bad data, do not include it in the tree"
+		max_low_coverage_sites: "If a diff file has higher than this percent (0.5 = 50%) bad data, do not include it in the tree"
 		decorate_tree: "Should usher, taxonium, and NextStrain trees be generated? Requires input_tree and ref_genome"
 		fastqc_on_timeout: "If true, fastqc one read from a sample when decontamination or variant calling times out"
 		force_diff: "If true and if decorate_tree is false, generate diff files. (Diff files will always be created if decorate_tree is true.)"
 		input_tree: "Base tree to use if decorate_tree = true"
-		min_coverage: "Positions with coverage below this value will be masked in diff files"
+		min_coverage_per_site: "Positions with coverage below this value will be masked in diff files"
 		paired_fastq_sets: "Nested array of paired fastqs, each inner array representing one samples worth of paired fastqs"
 		ref_genome_for_tree_building: "Ref genome for building trees -- must have ONLY `>NC_000962.3` on its first line"
 		subsample_cutoff: "If a fastq file is larger than than size in MB, subsample it with seqtk (set to -1 to disable)"
@@ -117,7 +117,7 @@ workflow myco {
 			input:
 				bam = vcfs_and_bams.left,
 				vcf = vcfs_and_bams.right,
-				min_coverage = min_coverage,
+				min_coverage_per_site = min_coverage_per_site,
 				tbmf = typical_tb_masked_regions,
 				diffs = create_diff_files
 		}
@@ -134,7 +134,7 @@ workflow myco {
 				input_mutation_annotated_tree = input_tree,
 				ref = ref_genome_for_tree_building,
 				coverage_reports = coerced_reports,
-				bad_data_threshold = bad_data_threshold
+				max_low_coverage_sites = max_low_coverage_sites
 		}
 	}
 

--- a/myco_raw.wdl
+++ b/myco_raw.wdl
@@ -1,12 +1,12 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/new-dockers/tasks/combined_decontamination.wdl" as clckwrk_combonation
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/new-dockers/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.9.0/tasks/combined_decontamination.wdl" as clckwrk_combonation
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.9.0/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
 import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.11/tasks/processing_tasks.wdl" as sranwrp_processing
 import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.6/tree_nine.wdl" as build_treesWF
 import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.7/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/fastqc-wdl/main/fastqc.wdl" as fastqc
-import "https://raw.githubusercontent.com/aofarrel/tb_profiler/main/tbprofiler_tasks.wdl" as profiler
+import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.2.1/tbprofiler_tasks.wdl" as profiler
 
 workflow myco {
 	input {

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -14,13 +14,13 @@ workflow myco {
 		File biosample_accessions
 		File typical_tb_masked_regions
 
-		Float   bad_data_threshold = 0.05
 		Boolean decorate_tree      = false
 		Boolean fastqc_on_timeout  = false
 		Boolean force_diff         = false
 		File?   input_tree
-		Int     min_coverage = 10
-		File   ref_genome_for_tree_building
+		Float   max_low_coverage_sites = 0.05
+		Int     min_coverage_per_site = 10
+		File    ref_genome_for_tree_building
 		Int     subsample_cutoff       =  450
 		Int     subsample_seed         = 1965
 		Int     timeout_decontam_part1 =   20
@@ -30,12 +30,12 @@ workflow myco {
 
 	parameter_meta {
 		biosample_accessions: "File of BioSample accessions to pull, one accession per line"
-		bad_data_threshold: "If a diff file has higher than this percent (0.5 = 50%) bad data, do not include it in the tree"
+		max_low_coverage_sites: "If a diff file has higher than this percent (0.5 = 50%) bad data, do not include it in the tree"
 		decorate_tree: "Should usher, taxonium, and NextStrain trees be generated? Requires input_tree and ref_genome"
 		fastqc_on_timeout: "If true, fastqc one read from a sample when decontamination or variant calling times out"
 		force_diff: "If true and if decorate_tree is false, generate diff files. (Diff files will always be created if decorate_tree is true.)"
 		input_tree: "Base tree to use if decorate_tree = true"
-		min_coverage: "Positions with coverage below this value will be masked in diff files"
+		min_coverage_per_site: "Positions with coverage below this value will be masked in diff files"
 		ref_genome_for_tree_building: "Ref genome for building trees iff different from ref genome used to call variants -- must have ONLY `>NC_000962.3` on its first line"
 		subsample_cutoff: "If a fastq file is larger than than size in MB, subsample it with seqtk (set to -1 to disable)"
 		subsample_seed: "Seed used for subsampling with seqtk"
@@ -123,7 +123,7 @@ workflow myco {
 			input:
 				bam = vcfs_and_bams.left,
 				vcf = vcfs_and_bams.right,
-				min_coverage = min_coverage,
+				min_coverage_per_site = min_coverage_per_site,
 				tbmf = typical_tb_masked_regions,
 				diffs = create_diff_files
 		}
@@ -176,7 +176,7 @@ workflow myco {
 				input_mutation_annotated_tree = input_tree,
 				ref = ref_genome_for_tree_building,
 				coverage_reports = coerced_reports,
-				bad_data_threshold = bad_data_threshold
+				max_low_coverage_sites = max_low_coverage_sites
 		}
 	}
 

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -160,21 +160,21 @@ workflow myco {
 		Array[File] bad_fastqs_decontam_ = select_all(decontam_each_sample.check_this_fastq)
 		Array[File] bad_fastqs_varcallr_ = select_all(variant_call_each_sample.check_this_fastq)
 		Array[Array[File]] bad_fastqs_   = [bad_fastqs_decontam_, bad_fastqs_varcallr_]
-		if(length(decontam_each_sample.check_this_fastq)>1 && length(bad_fastqs_varcallr_)>1) {
+		if(length(decontam_each_sample.check_this_fastq)>=1 && length(bad_fastqs_varcallr_)>=1) {
 			Array[File] bad_fastqs_both  = flatten(bad_fastqs_)  
 			call debug_bad_fastqs_both { 
 				input: 
 					bad_fastqs_both = bad_fastqs_both
 			}
 		}
-		if(length(decontam_each_sample.check_this_fastq)>1) {
+		if(length(decontam_each_sample.check_this_fastq)>=1) {
 			Array[File] bad_fastqs_decontam = select_all(bad_fastqs_decontam_)
 			call debug_bad_fastqs_decontam { 
 				input: 
 					bad_fastqs_decontam = bad_fastqs_decontam
 			}
 		}
-		if(length(bad_fastqs_varcallr_)>1) {
+		if(length(bad_fastqs_varcallr_)>=1) {
 			Array[File] bad_fastqs_varcallr = select_all(bad_fastqs_varcallr_)
 			call debug_bad_fastqs_varcallr { 
 				input: 
@@ -186,7 +186,7 @@ workflow myco {
 			input:
 				fastqs = fastqs
 		}
-		if(length(fastqs)>1) {
+		if(length(fastqs)>=1) {
 			call fastqc.FastqcWF {
 				input:
 					fastqs = fastqs

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -7,7 +7,7 @@ import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.11/tasks/process
 import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.6/tree_nine.wdl" as build_treesWF
 import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.7/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/fastqc-wdl/main/fastqc.wdl" as fastqc
-import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.1.3/tb_profiler.wdl" as profiler
+import "https://raw.githubusercontent.com/aofarrel/tb_profiler/main/tb_profiler.wdl" as profiler
 
 workflow myco {
 	input {
@@ -105,6 +105,13 @@ workflow myco {
     			[decontam_each_sample.decontaminated_fastq_2, 
     				biosample_accessions])
 
+			
+			call profiler.tb_profiler_fastq as profile {
+				input:
+					fastqs = [real_decontaminated_fastq_1, real_decontaminated_fastq_2]
+			}
+
+
 			call clckwrk_var_call.variant_call_one_sample_ref_included as variant_call_each_sample {
 				input:
 					reads_files = [real_decontaminated_fastq_1, real_decontaminated_fastq_2],
@@ -128,10 +135,6 @@ workflow myco {
 				diffs = create_diff_files
 		}
 
-		call profiler.tb_profiler_bam as profile {
-			input:
-				bam = vcfs_and_bams.left
-		}
 	}
 	
 	call sranwrp_processing.cat_strings as cat_strains {

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -137,7 +137,7 @@ workflow myco {
 
 	}
 
-	if(length(profile.tbprofiler_strain)>1) {
+	if(defined(profile.tbprofiler_strain)) {
 		Array[String] coerced_strains=select_all(profile.tbprofiler_strain)
 		Array[String] coerced_resistance=select_all(profile.tbprofiler_resistance)
 

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.8.0/workflows/refprep-TB.wdl" as clockwork_ref_prepWF
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.8.0/tasks/combined_decontamination.wdl" as clckwrk_combonation
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.8.0/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/new-dockers/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
 import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.10/tasks/pull_fastqs.wdl" as sranwrp_pull
 import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.10/tasks/processing_tasks.wdl" as sranwrp_processing
 import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.5/tree_nine.wdl" as build_treesWF
@@ -111,9 +111,8 @@ workflow myco {
     			[per_sample_decontam.decontaminated_fastq_2, 
     				biosample_accessions])
 
-			call clckwrk_var_call.variant_call_one_sample_simple as varcall_with_array {
+			call clckwrk_var_call.variant_call_one_sample_ref_included as varcall_with_array {
 				input:
-					ref_dir = ClockworkRefPrepTB.tar_indexd_H37Rv_ref,
 					reads_files = [real_decontaminated_fastq_1, real_decontaminated_fastq_2],
 					timeout = timeout_variant_caller
 			}

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -136,18 +136,25 @@ workflow myco {
 		}
 
 	}
+
+	if(length(profile.tbprofiler_strain)>1) {
+		Array[String] coerced_strains=select_all(profile.tbprofiler_strain)
+		Array[String] coerced_resistance=select_all(profile.tbprofiler_resistance)
+
+		call sranwrp_processing.cat_strings as cat_strains {
+			input:
+				strings = coerced_strains,
+				out = "strain_reports.txt"
+		}
+		
+		call sranwrp_processing.cat_strings as cat_resistance {
+			input:
+				strings = coerced_resistance,
+				out = "resistance_reports.txt"
+		}
+  	}
 	
-	call sranwrp_processing.cat_strings as cat_strains {
-		input:
-			strings = profile.tbprofiler_strain,
-			out = "strain_reports.txt"
-	}
 	
-	call sranwrp_processing.cat_strings as cat_resistance {
-		input:
-			strings = profile.tbprofiler_resistance,
-			out = "resistance_reports.txt"
-	}
 
 	if(fastqc_on_timeout) {
 		Array[File] bad_fastqs_decontam_ = select_all(decontam_each_sample.check_this_fastq)
@@ -185,11 +192,11 @@ workflow myco {
 
 	output {
 		File download_report = merge_reports.outfile
-		File strain_report = cat_strains.outfile
-		File resistance_report = cat_resistance.outfile
+		File? strain_report = cat_strains.outfile
+		File? resistance_report = cat_resistance.outfile
 		Array[File] minos = minos_vcfs
 		Array[File] masks = make_mask_and_diff.mask_file
-		Array[File] tbprofiler_debug_texts = profile.tbprofiler_txt
+		Array[File?]? tbprofiler_texts = profile.tbprofiler_txt
 		Array[File?] diffs = make_mask_and_diff.diff
 		File? tree_usher = trees.usher_tree
 		File? tree_taxonium = trees.taxonium_tree

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -5,7 +5,7 @@ import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/new-dockers/tas
 import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.10/tasks/pull_fastqs.wdl" as sranwrp_pull
 import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.11/tasks/processing_tasks.wdl" as sranwrp_processing
 import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.6/tree_nine.wdl" as build_treesWF
-import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.6/vcf_to_diff.wdl" as diff
+import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.7/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/fastqc-wdl/main/fastqc.wdl" as fastqc
 import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.1.3/tb_profiler.wdl" as profiler
 

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -3,9 +3,9 @@ version 1.0
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/new-dockers/tasks/combined_decontamination.wdl" as clckwrk_combonation
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/new-dockers/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
 import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.10/tasks/pull_fastqs.wdl" as sranwrp_pull
-import "https://raw.githubusercontent.com/aofarrel/SRANWRP/main/tasks/processing_tasks.wdl" as sranwrp_processing
-import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.5/tree_nine.wdl" as build_treesWF
-import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.4/vcf_to_diff.wdl" as diff
+import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.11/tasks/processing_tasks.wdl" as sranwrp_processing
+import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.6/tree_nine.wdl" as build_treesWF
+import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.6/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/fastqc-wdl/main/fastqc.wdl" as fastqc
 import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.1.3/tb_profiler.wdl" as profiler
 

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -169,10 +169,14 @@ workflow myco {
 		if(length(bad_fastqs_varcallr_)>1) {
 			Array[File] bad_fastqs_varcallr = select_all(bad_fastqs_varcallr_)
 		}
-		call fastqc.FastqcWF {
-			input:
-				fastqs = select_first([bad_fastqs_both, bad_fastqs_decontam, bad_fastqs_varcallr])
+		Array[File] fastqs = select_first([bad_fastqs_both, bad_fastqs_decontam, bad_fastqs_varcallr])
+		if(length(fastqs)>1) {
+			call fastqc.FastqcWF {
+				input:
+					fastqs = fastqs
+			}
 		}
+		
 	}
 
 	if(decorate_tree) {

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -186,7 +186,7 @@ workflow myco {
 			input:
 				fastqs = fastqs
 		}
-		if(length(fastqs)>=1) {
+		if(length(fastqs)>0) {
 			call fastqc.FastqcWF {
 				input:
 					fastqs = fastqs

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -161,15 +161,31 @@ workflow myco {
 		Array[File] bad_fastqs_varcallr_ = select_all(variant_call_each_sample.check_this_fastq)
 		Array[Array[File]] bad_fastqs_   = [bad_fastqs_decontam_, bad_fastqs_varcallr_]
 		if(length(decontam_each_sample.check_this_fastq)>1 && length(bad_fastqs_varcallr_)>1) {
-			Array[File] bad_fastqs_both      = flatten(bad_fastqs_)  
+			Array[File] bad_fastqs_both  = flatten(bad_fastqs_)  
+			call debug_bad_fastqs_both { 
+				input: 
+					bad_fastqs_both = bad_fastqs_both
+			}
 		}
 		if(length(decontam_each_sample.check_this_fastq)>1) {
-			Array[File] bad_fastqs_decontam = select_all(decontam_each_sample.check_this_fastq)
+			Array[File] bad_fastqs_decontam = select_all(bad_fastqs_decontam_)
+			call debug_bad_fastqs_decontam { 
+				input: 
+					bad_fastqs_decontam = bad_fastqs_decontam
+			}
 		}
 		if(length(bad_fastqs_varcallr_)>1) {
 			Array[File] bad_fastqs_varcallr = select_all(bad_fastqs_varcallr_)
+			call debug_bad_fastqs_varcallr { 
+				input: 
+					bad_fastqs_varcallr = bad_fastqs_varcallr
+			}
 		}
 		Array[File] fastqs = select_first([bad_fastqs_both, bad_fastqs_decontam, bad_fastqs_varcallr])
+		call debug_fastqs {
+			input:
+				fastqs = fastqs
+		}
 		if(length(fastqs)>1) {
 			call fastqc.FastqcWF {
 				input:
@@ -208,4 +224,32 @@ workflow myco {
 		Array[File]? trees_nextstrain = trees.nextstrain_subtrees
 		Array[File]? fastqc_reports = FastqcWF.reports
 	}
+}
+
+task debug_bad_fastqs_both {
+	input {
+		Array[String] bad_fastqs_both
+	}
+	command <<< >>>
+}
+
+task debug_bad_fastqs_decontam {
+	input {
+		Array[String] bad_fastqs_decontam
+	}
+	command <<< >>>
+}
+
+task debug_bad_fastqs_varcallr {
+	input {
+		Array[String] bad_fastqs_varcallr
+	}
+	command <<< >>>
+}
+
+task debug_fastqs {
+	input {
+		Array[String] fastqs
+	}
+	command <<< >>>
 }

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -1,13 +1,13 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/new-dockers/tasks/combined_decontamination.wdl" as clckwrk_combonation
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/new-dockers/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.9.0/tasks/combined_decontamination.wdl" as clckwrk_combonation
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.9.0/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
 import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.10/tasks/pull_fastqs.wdl" as sranwrp_pull
 import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.11/tasks/processing_tasks.wdl" as sranwrp_processing
 import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.6/tree_nine.wdl" as build_treesWF
 import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.7/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/fastqc-wdl/main/fastqc.wdl" as fastqc
-import "https://raw.githubusercontent.com/aofarrel/tb_profiler/main/tbprofiler_tasks.wdl" as profiler
+import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.2.1/tbprofiler_tasks.wdl" as profiler
 
 
 workflow myco {

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -7,7 +7,7 @@ import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.11/tasks/process
 import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.6/tree_nine.wdl" as build_treesWF
 import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.7/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/fastqc-wdl/main/fastqc.wdl" as fastqc
-import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.2.0/tbprofiler_tasks.wdl" as profiler
+import "https://raw.githubusercontent.com/aofarrel/tb_profiler/main/tbprofiler_tasks.wdl" as profiler
 
 
 workflow myco {

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -231,6 +231,13 @@ task debug_bad_fastqs_both {
 		Array[String] bad_fastqs_both
 	}
 	command <<< >>>
+	runtime {
+		cpu: 4
+		docker: "ashedpotatoes/sranwrp:1.1.6"
+		disks: "local-disk 5 HDD"
+		memory: "2 GB"
+		preemptible: "3"
+	}
 }
 
 task debug_bad_fastqs_decontam {
@@ -238,6 +245,13 @@ task debug_bad_fastqs_decontam {
 		Array[String] bad_fastqs_decontam
 	}
 	command <<< >>>
+	runtime {
+		cpu: 4
+		docker: "ashedpotatoes/sranwrp:1.1.6"
+		disks: "local-disk 5 HDD"
+		memory: "2 GB"
+		preemptible: "3"
+	}
 }
 
 task debug_bad_fastqs_varcallr {
@@ -245,6 +259,13 @@ task debug_bad_fastqs_varcallr {
 		Array[String] bad_fastqs_varcallr
 	}
 	command <<< >>>
+	runtime {
+		cpu: 4
+		docker: "ashedpotatoes/sranwrp:1.1.6"
+		disks: "local-disk 5 HDD"
+		memory: "2 GB"
+		preemptible: "3"
+	}
 }
 
 task debug_fastqs {
@@ -252,4 +273,11 @@ task debug_fastqs {
 		Array[String] fastqs
 	}
 	command <<< >>>
+	runtime {
+		cpu: 4
+		docker: "ashedpotatoes/sranwrp:1.1.6"
+		disks: "local-disk 5 HDD"
+		memory: "2 GB"
+		preemptible: "3"
+	}
 }


### PR DESCRIPTION
* Several task and variable names have been updated for better clarity 
* Update prereqs
  * Use new Dockers for the variant caller and decontamination tasks, which allows us to avoid using refprep and skip some reference-related variables
  * TBProfiler task now reports median depth
* myco_raw now outputs collated depth, resistance, and strain like myco_sra
* Add an FAQ

Note that myco_cleaned largely is unchanged other than changes to variable/task names, and might be deprecated in the future.