### PR TITLE
Implement covstats filtering

### DIFF
--- a/doc/doc_making_resources/generate_inputs_md.sh
+++ b/doc/doc_making_resources/generate_inputs_md.sh
@@ -1,3 +1,7 @@
+### DEPRECATED ###
+exit 0
+
+
 # This is very much a Works On My Machine sort of script!
 # To run this elsewhere, point to your own version of womtool,
 # change ghead to head (unless you're using Mac w/ coreutils),
@@ -70,7 +74,7 @@ filename_vars = [
 def strip_junk(string):
 	"""
 	The python to markdown converter we're using seems to do some character replacements to ensure
-	greater markdown compatiability, but they render awfully GitHub. This function undos that.
+	greater markdown compatiability, but they render awfully on GitHub. This function undos that.
 	"""
 	return string.replace("&gt;", ">").replace("&quot;", "'").replace(": ", "").replace("&#x27;", "\`").replace("&lt;", "<").replace("\`", "\'")
 
@@ -244,6 +248,7 @@ with open("myco_cleaned.wdl", "r") as myco:
 fastq_inputs = []
 for input_variable in workflow_level:
 	value = input_variable["name"]
+	print(input_variable)
 	if value == "biosample_accessions":
 		input_variable["workflow"] = "myco_sra"
 		del input_variable["default"]

--- a/doc/doc_making_resources/generate_workflow_level_readmes.sh
+++ b/doc/doc_making_resources/generate_workflow_level_readmes.sh
@@ -1,5 +1,7 @@
 # WIP -- not currently used
-#
+exit 0
+
+
 # relies on https://github.com/Nicceboy/python-markdown-generator
 
 python3 << CODE

--- a/doc/inputs.md
+++ b/doc/inputs.md
@@ -43,38 +43,37 @@ myco_cleaned expects that the FASTQs you are putting into have already been clea
 ### Timeouts  
 When working with data of unknown quality such as SRA data, it can be helpful to quickly remove samples that are likely low-quality. While developing myco on SRA data, we noticed that if a given sample took an unusually long time in the decontamination or variant calling step, they were likely to end up filtered out by the final quality control steps of the pipeline. This is especially true of the decontamination step -- the more contamination a sample has, the more that step has to do. This heuristic was defined on the default runtime attributes and using Terra as a backend, so straying from those defaults is likely to make the default timeout values less useful. This *includes* changing from SDDs to HDDs! 
 
- myco_raw and myco_cleaned default to not using this heuristic at all.  
   
-| name | type | default | description | workflow |  
-|:---:|:---:|:---:|:---:|:---:|  
-| timeout_decontam_part1 | Int  | 0 | Discard any sample that is still running in clockwork map_reads after this many minutes (set to 0 to never timeout | myco_raw, myco_cleaned |  
-| timeout_decontam_part1 | Int  | 20 | Discard any sample that is still running in clockwork map_reads after this many minutes (set to 0 to never timeout | myco_sra |  
-| timeout_decontam_part2 | Int  | 0 | Discard any sample that is still running in clockwork rm_contam after this many minutes (set to 0 to never timeout) | myco_raw, myco_cleaned |  
-| timeout_decontam_part2 | Int  | 15 | Discard any sample that is still running in clockwork rm_contam after this many minutes (set to 0 to never timeout) | myco_sra |  
-| timeout_variant_caller | Int  | 0 | Discard any sample that is still running in clockwork variant_call_one_sample after this many minutes (set to 0 to never timeout) | myco_raw, myco_cleaned |  
-| timeout_variant_caller | Int  | 120 | Discard any sample that is still running in clockwork variant_call_one_sample after this many minutes (set to 0 to never timeout) | myco_sra |  
+| name | type | myco_sra default | description |  
+|:---:|:---:|:---:|:---:|  
+| timeout_decontam_part1 | Int  | 20<sup>†</sup> | Discard any sample that is still running in clockwork map_reads after this many minutes (set to 0 to never timeout |
+| timeout_decontam_part2 | Int  | 15<sup>†</sup>  | Discard any sample that is still running in clockwork rm_contam after this many minutes (set to 0 to never timeout) |  
+| timeout_variant_caller | Int  | 120<sup>†</sup> | Discard any sample that is still running in clockwork variant_call_one_sample after this many minutes (set to 0 to never timeout) | 
+
+<sup>†</sup> myco_raw and myco_cleaned default to not using this heuristic at all, so their defaults are 0.
   
   
 ### Miscellanous workflow-level inputs  
   
 | name | type | default | description |  
 |:---:|:---:|:---:|:---:|  
-| decorate_tree | Boolean  | false | Should usher, taxonium, and NextStrain trees be generated? |  
+| diff_force | Boolean  | false | If true and if decorate_tree is false, generate diff files. (Diff files will always be created if decorate_tree is true.) |  
+| diff_mask_these_regions | File? | [this CRyPTIC mask file](https://github.com/iqbal-lab-org/cryptic_tb_callable_mask/blob/44f884558bea4ee092ce7c5c878561200fcee92f/R00000039_repregions.bed) | Bed file of regions to mask when making diff files |  
+| diff_min_coverage_per_site | Int  | 10 | Positions with coverage below this value will be masked in diff files |
 | early_qc_apply_cutoffs | Boolean  | false | If true, run fastp + TBProfiler on decontaminated fastqs and apply cutoffs to determine which samples should be thrown out. |  
 | early_qc_cutoff_q30 | Float  | 0.9 | Decontaminated samples with less than this percentage (as float, 0.5 = 50%) of reads above qual score of 30 will be discarded iff early_qc_apply_cutoffs is also true. |  
 | early_qc_skip_entirely | Boolean  | false | Do not run early QC (fastp + fastq-TBProfiler) at all. Does not affect whether or not TBProfiler is later run on bams. Overrides early_qc_apply_cutoffs. |  
-| fastqc_on_timeout | Boolean  | false | If true, fastqc one read from a sample when decontamination or variant calling times out |  
-| force_diff | Boolean  | false | If true and if decorate_tree is false, generate diff files. (Diff files will always be created if decorate_tree is true.) |  
-| input_tree | File? |  | Base tree to use if decorate_tree = true |  
-| max_low_coverage_sites | Float  | 0.05 | If a diff file has higher than this percent (0.5 = 50%) bad data, do not include it in the tree |  
-| min_coverage_per_site | Int  | 10 | Positions with coverage below this value will be masked in diff files |  
-| ref_genome_for_tree_building | File? |  | Ref genome for building trees -- must have ONLY '>NC_000962.3' on its first line |  
+| fastqc_on_timeout | Boolean  | false | (myco_sra only) If true, fastqc one read from a sample when decontamination or variant calling times out |  
 | subsample_cutoff | Int  | 450 | If a fastq file is larger than than size in MB, subsample it with seqtk (set to -1 to disable) |  
 | subsample_seed | Int  | 1965 | Seed used for subsampling with seqtk |  
-| tbprofiler_on_bam | Boolean  | false | If true, run TBProfiler on BAMs |  
-| tbprofiler_on_bam | Boolean  | true | If true, run TBProfiler on BAMs |  
-| typical_tb_masked_regions | File? |  | Bed file of regions to mask when making diff files |  
+| tbprofiler_on_bam | Boolean  | varies<sup>†</sup> | If true, run TBProfiler on BAMs |  
+| tree_decoration | Boolean  | false | Should usher, taxonium, and NextStrain trees be generated? |  
+| tree_max_low_coverage_sites | Float  | 0.05 | If a diff file has higher than this percent (0.5 = 50%) bad data, do not include it in the tree |  
+| tree_to_decorate | File? | [this draft tree](https://console.cloud.google.com/storage/browser/_details/topmed_workflow_testing/tb/trees/alldiffs_mask2ref.L.fixed.pb;tab=live_object) | Base tree to use if decorate_tree = true |  
+
+<sup>†</sup> Defaults to true for myco_sra and false for myco_raw for historical reasons
   
+
   
 ## Task-level inputs  
   

--- a/myco_raw.wdl
+++ b/myco_raw.wdl
@@ -6,7 +6,7 @@ import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.12/tasks/process
 import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.10/tree_nine.wdl" as build_treesWF
 import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.9/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.2.2/tbprofiler_tasks.wdl" as profiler
-import "https://raw.githubusercontent.com/aofarrel/TBfastProfiler/main/TBfastProfiler.wdl" as qc_fastqsWF # aka earlyQC
+import "https://raw.githubusercontent.com/aofarrel/TBfastProfiler/0.0.5/TBfastProfiler.wdl" as qc_fastqsWF # aka earlyQC
 import "https://raw.githubusercontent.com/aofarrel/goleft-wdl/0.1.2/goleft_functions.wdl" as goleft
 
 

--- a/myco_raw.wdl
+++ b/myco_raw.wdl
@@ -1,39 +1,45 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.9.1/tasks/combined_decontamination.wdl" as clckwrk_combonation
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/main/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.9.2/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
 import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.12/tasks/processing_tasks.wdl" as sranwrp_processing
 import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.10/tree_nine.wdl" as build_treesWF
 import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.9/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.2.2/tbprofiler_tasks.wdl" as profiler
-import "https://raw.githubusercontent.com/aofarrel/TBfastProfiler/0.0.4/TBfastProfiler.wdl" as qc_fastqsWF # aka earlyQC
+import "https://raw.githubusercontent.com/aofarrel/TBfastProfiler/main/TBfastProfiler.wdl" as qc_fastqsWF # aka earlyQC
+import "https://raw.githubusercontent.com/aofarrel/goleft-wdl/0.1.2/covstats.wdl" as covstatsWF
+
 
 workflow myco {
 	input {
 		Array[Array[File]] paired_fastq_sets
-
-		Boolean decorate_tree                   = false
+		
+		# TODO: REPLACE WITH BETTER DEFAULTS
+		Float   covstats_qc_cutoff_coverages    =   10.00
+		Float   covstats_qc_cutoff_unmapped     =    0.10
+		Boolean covstats_qc_skip_entirely       = false
+		
+		Boolean diff_force                      = false
+		File?   diff_mask_these_regions
+		Int     diff_min_coverage_per_site      =   10
 		Boolean early_qc_apply_cutoffs          = false
 		Float   early_qc_cutoff_q30             =    0.90
 		Boolean early_qc_skip_entirely          = false
-		Boolean fastqc_on_timeout               = false
-		Boolean force_diff                      = false
-		File?   input_tree
-		Float   max_low_coverage_sites          =    0.05
-		Int     min_coverage_per_site           =   10
 		Int     quick_tasks_disk_size           =   10 
-		File?   ref_genome_for_tree_building
-		Int     subsample_cutoff                =  450
+		Int     subsample_cutoff                =   -1
 		Int     subsample_seed                  = 1965
 		Boolean tbprofiler_on_bam               = false
 		Int     timeout_decontam_part1          =    0
 		Int     timeout_decontam_part2          =    0
 		Int     timeout_variant_caller          =    0
-		File?   typical_tb_masked_regions
+		Boolean tree_decoration                 = false
+		Float   tree_max_low_coverage_sites     =    0.05
+		File?   tree_to_decorate
 		Int     variantcalling_addl_disk        =  100
 		Boolean variantcalling_crash_on_error   = false
 		Boolean variantcalling_crash_on_timeout = false
 		Int     variantcalling_cpu              =   16
+		Boolean variantcalling_debug            = false
 		Int?    variantcalling_mem_height
 		Int     variantcalling_memory           =   32
 		Int     variantcalling_preemptibles     =    1
@@ -42,32 +48,35 @@ workflow myco {
 	}
 
 	parameter_meta {
-		decorate_tree: "Should usher, taxonium, and NextStrain trees be generated?"
+		covstats_qc_cutoff_coverages: "If covstats thinks coverage is below this, throw out this sample"
+		covstats_qc_cutoff_unmapped: "If covstats thinks this porportion (as float, 0.5 = 50%) of data does not map to H37Rv, throw out this sample"
+		covstats_qc_skip_entirely: "Should we skip covstats entirely?"
+		diff_force: "If true and if decorate_tree is false, generate diff files. (Diff files will always be created if decorate_tree is true.)"
+		diff_mask_these_regions: "Bed file of regions to mask when making diff files"
+		diff_min_coverage_per_site: "Positions with coverage below this value will be masked in diff files"
 		early_qc_apply_cutoffs: "If true, run fastp + TBProfiler on decontaminated fastqs and apply cutoffs to determine which samples should be thrown out."
-		early_qc_cutoff_q30: "Decontaminated samples with less than this percentage (as float, 0.5 = 50%) of reads above qual score of 30 will be discarded iff early_qc_apply_cutoffs is also true."
+		early_qc_cutoff_q30: "Decontaminated samples with less than this porportion (as float, 0.5 = 50%) of reads above qual score of 30 will be discarded iff early_qc_apply_cutoffs is also true."
 		early_qc_skip_entirely: "Do not run early QC (fastp + fastq-TBProfiler) at all. Does not affect whether or not TBProfiler is later run on bams. Overrides early_qc_apply_cutoffs."
-		fastqc_on_timeout: "If true, fastqc one read from a sample when decontamination or variant calling times out"
-		force_diff: "If true and if decorate_tree is false, generate diff files. (Diff files will always be created if decorate_tree is true.)"
-		input_tree: "Base tree to use if decorate_tree = true"
-		max_low_coverage_sites: "If a diff file has higher than this percent (0.5 = 50%) bad data, do not include it in the tree"
-		min_coverage_per_site: "Positions with coverage below this value will be masked in diff files"
+		quick_tasks_disk_size: "Disk size in GB to use for quick file-processing tasks; increasing this might slightly speed up file localization"
 		paired_fastq_sets: "Nested array of paired fastqs, each inner array representing one samples worth of paired fastqs"
 		ref_genome_for_tree_building: "Ref genome for building trees -- must have ONLY `>NC_000962.3` on its first line"
 		subsample_cutoff: "If a fastq file is larger than than size in MB, subsample it with seqtk (set to -1 to disable)"
 		subsample_seed: "Seed used for subsampling with seqtk"
 		tbprofiler_on_bam: "If true, run TBProfiler on BAMs"
-		timeout_decontam_part1: "Discard any sample that is still running in clockwork map_reads after this many minutes (set to 0 to never timeout"
+		timeout_decontam_part1: "Discard any sample that is still running in clockwork map_reads after this many minutes (set to 0 to never timeout)"
 		timeout_decontam_part2: "Discard any sample that is still running in clockwork rm_contam after this many minutes (set to 0 to never timeout)"
 		timeout_variant_caller: "Discard any sample that is still running in clockwork variant_call_one_sample after this many minutes (set to 0 to never timeout)"
-		typical_tb_masked_regions: "Bed file of regions to mask when making diff files"
+		tree_decoration: "Should usher, taxonium, and NextStrain trees be generated?"
+		tree_max_low_coverage_sites: "If a diff file has higher than this porportion (0.5 = 50%) bad data, do not include it in the tree"
+		tree_to_decorate: "Base tree to use if tree_decoration = true"
 	}
 
 	# WDL doesn't understand mutual exclusivity, so we have to get a little creative on 
 	# our determination of whether or not we want to create diff files.
-	if(decorate_tree)  {  Boolean create_diff_files_   = true  }
-	if(!decorate_tree) {
-		if(!force_diff){  Boolean create_diff_files__  = false }
-		if(force_diff) {  Boolean create_diff_files___ = true  }
+	if(tree_decoration)  {  Boolean create_diff_files_   = true  }
+	if(!tree_decoration) {
+		if(!tree_decoration){  Boolean create_diff_files__  = false }
+		if(tree_decoration) {  Boolean create_diff_files___ = true  }
 	}
 	Boolean create_diff_files = select_first([create_diff_files_,
 											  create_diff_files__, 
@@ -110,11 +119,13 @@ workflow myco {
 								cpu = variantcalling_cpu,
 								crash_on_error = variantcalling_crash_on_error,
 								crash_on_timeout = variantcalling_crash_on_timeout,
+								debug = variantcalling_debug,
 								mem_height = variantcalling_mem_height,
 								memory = variantcalling_memory,
 								preempt = variantcalling_preemptibles,
 								retries = variantcalling_retries,
 								ssd = variantcalling_ssd,
+								tarball_bams_and_bais = false,
 								timeout = timeout_variant_caller
 						}
 					}
@@ -131,11 +142,13 @@ workflow myco {
 							cpu = variantcalling_cpu,
 							crash_on_error = variantcalling_crash_on_error,
 							crash_on_timeout = variantcalling_crash_on_timeout,
+							debug = variantcalling_debug,
 							mem_height = variantcalling_mem_height,
 							memory = variantcalling_memory,
 							preempt = variantcalling_preemptibles,
 							retries = variantcalling_retries,
 							ssd = variantcalling_ssd,
+							tarball_bams_and_bais = false,
 							timeout = timeout_variant_caller
 					}
 				}
@@ -150,11 +163,13 @@ workflow myco {
 						cpu = variantcalling_cpu,
 						crash_on_error = variantcalling_crash_on_error,
 						crash_on_timeout = variantcalling_crash_on_timeout,
+						debug = variantcalling_debug,
 						mem_height = variantcalling_mem_height,
 						memory = variantcalling_memory,
 						preempt = variantcalling_preemptibles,
 						retries = variantcalling_retries,
 						ssd = variantcalling_ssd,
+						tarball_bams_and_bais = false,
 						timeout = timeout_variant_caller
 				}
 			}
@@ -171,27 +186,79 @@ workflow myco {
 	Array[File] bams_if_earlyQC_but_not_filtering = select_all(variant_call_after_earlyQC_but_not_filtering_samples.bam)
 	Array[File] bams_if_no_earlyQC = select_all(variant_call_without_earlyQC.bam)
 	
+	Array[File] bais_if_earlyQC_filtered = select_all(variant_call_after_earlyQC_filtering.bai)
+	Array[File] bais_if_earlyQC_but_not_filtering = select_all(variant_call_after_earlyQC_but_not_filtering_samples.bai)
+	Array[File] bais_if_no_earlyQC = select_all(variant_call_without_earlyQC.bai)
+	
 	Array[File] minos_vcfs = flatten([minos_vcfs_if_earlyQC_filtered, minos_vcfs_if_earlyQC_but_not_filtering, minos_vcfs_if_no_earlyQC])
-	Array[File] bams_to_ref = flatten([bams_if_earlyQC_filtered, bams_if_earlyQC_but_not_filtering, bams_if_no_earlyQC])
+	Array[File] final_bams = flatten([bams_if_earlyQC_filtered, bams_if_earlyQC_but_not_filtering, bams_if_no_earlyQC])
+	Array[File] final_bais = flatten([bais_if_earlyQC_filtered, bais_if_earlyQC_but_not_filtering, bais_if_no_earlyQC])
 	
+	Array[Array[File]] bams_and_bais = [final_bams, final_bais]
+	Array[Array[File]] bam_per_bai = transpose(bams_and_bais)
 	
-	scatter(vcfs_and_bams in zip(bams_to_ref, minos_vcfs)) {
-		call diff.make_mask_and_diff as make_mask_and_diff {
-			input:
-				bam = vcfs_and_bams.left,
-				vcf = vcfs_and_bams.right,
-				min_coverage_per_site = min_coverage_per_site,
-				tbmf = typical_tb_masked_regions,
-				diffs = create_diff_files
+	scatter(vcfs_and_bams in zip(bam_per_bai, minos_vcfs)) {
+	# scatter(vcfs_and_bams in zip(bam_per_bai, minos_vcfs)) is now sort of a three-way scatter:
+	# * bam file accessible via vcfs_and_bams.left[0]
+	# * bai file accessible via vcfs_and_bams.left[1]
+	# * vcf file accessible via vcfs_and_bams.right
+	
+	# This relies on your WDL executor being consistent with how it orders arrays. That SHOULD always be the case per
+	# the spec, but if things break catastrophically, let me save you some debug time: As of 2.9.2, clockwork-wdl's
+	# ref-included version of the variant caller has an option to output the bams and bais as a tarball. You can use
+	# that to recreate the simplier scatter of version 4.4.1 or earlier of myco. You will need to modify some tasks to
+	# untar things, of course.
+		if(!covstats_qc_skip_entirely) {
+	
+			# covstats to check coverage and percent mapped to reference
+			call covstatsWF.Covstats as covstats {
+				input:
+					bamsOrCrams = [vcfs_and_bams.left[0]],
+					baisOrCrais = [vcfs_and_bams.left[1]]
+			}
+			
+			if(covstats.percentUnmapped[0] > covstats_qc_cutoff_unmapped) {
+				if(covstats.coverages[0] > covstats_qc_cutoff_coverages) {
+					
+					# make diff files
+					call diff.make_mask_and_diff as make_mask_and_diff_after_covstats {
+						input:
+							bam = vcfs_and_bams.left[0],
+							vcf = vcfs_and_bams.right,
+							min_coverage_per_site = diff_min_coverage_per_site,
+							tbmf = diff_mask_these_regions,
+							diffs = create_diff_files
+					}
+				}
+			}
 		}
 		
+		if(covstats_qc_skip_entirely) {
+		
+			# make diff files
+			call diff.make_mask_and_diff as make_mask_and_diff_no_covstats {
+				input:
+					bam = vcfs_and_bams.left[0],
+					vcf = vcfs_and_bams.right,
+					min_coverage_per_site = diff_min_coverage_per_site,
+					tbmf = diff_mask_these_regions,
+					diffs = create_diff_files
+			}
+		}
+		
+		# TBProfiler (will run even if fails covstats qc)
 		if(tbprofiler_on_bam) {
 			call profiler.tb_profiler_bam as profile_bam {
 					input:
-						bam = vcfs_and_bams.left
+						bam = vcfs_and_bams.left[0]
 			}
 		}
 	}
+	
+	Array[File?] real_diffs = select_first([make_mask_and_diff_after_covstats.diff, make_mask_and_diff_no_covstats.diff])
+	Array[File?] real_reports = select_first([make_mask_and_diff_after_covstats.report, make_mask_and_diff_no_covstats.report])
+	Array[File?] real_masks = select_first([make_mask_and_diff_after_covstats.mask_file, make_mask_and_diff_no_covstats.mask_file])
+
 
 	# pull TBProfiler information, if we ran TBProfiler on bams
 	if(defined(profile_bam.strain)) {
@@ -241,44 +308,47 @@ workflow myco {
 		}
   	}
 
-	if(decorate_tree) {
-		# diff files must exist if decorate_tree is true, so we can force the Array[File?]?
+	if(tree_decoration) {
+		# diff files must exist if tree_decoration is true, so we can force the Array[File?]?
 		# into an Array[File] with the classic "select_first() with a bogus fallback" hack
-		Array[File] coerced_diffs = select_first([select_all(make_mask_and_diff.diff), minos_vcfs])
-		Array[File] coerced_reports = select_first([select_all(make_mask_and_diff.report), minos_vcfs])
+		Array[File] coerced_diffs = select_first([select_all(real_diffs), minos_vcfs])
+		Array[File] coerced_reports = select_first([select_all(real_reports), minos_vcfs])
 		call build_treesWF.Tree_Nine as trees {
 			input:
 				diffs = coerced_diffs,
-				input_tree = input_tree,
-				ref_genome = ref_genome_for_tree_building,
+				input_tree = tree_to_decorate,
 				coverage_reports = coerced_reports,
-				max_low_coverage_sites = max_low_coverage_sites
+				max_low_coverage_sites = tree_max_low_coverage_sites
 		}
 	}
 
 	output {
 		# raw files
-		Array[File?] diffs = make_mask_and_diff.diff
-		Array[File] masks = make_mask_and_diff.mask_file
-		Array[File] vcfs = minos_vcfs
+		Array[File]  bais = final_bais
+		Array[File]  bams  = final_bams
+		Array[File?] diffs = real_diffs
+		Array[File?] masks = real_masks   # bedgraph
+		Array[File]  vcfs  = minos_vcfs
 		
 		# metadata
-		Array[File?]? fastp_reports          = qc_fastqs.fastp_txt
+		Array[File?]  covstats_reports       = covstats.covstatsReport
+		Array[File?]  diff_reports           = real_reports
+		Array[File?]  fastp_reports          = qc_fastqs.fastp_txt
 		File?         tbprof_bam_depths      = collate_bam_depth.outfile
-		Array[File?]? tbprof_bam_jsons       = profile_bam.tbprofiler_json
+		Array[File?]  tbprof_bam_jsons       = profile_bam.tbprofiler_json
 		File?         tbprof_bam_strains     = collate_bam_strains.outfile
-		Array[File?]? tbprof_bam_summaries   = profile_bam.tbprofiler_txt
+		Array[File?]  tbprof_bam_summaries   = profile_bam.tbprofiler_txt
 		File?         tbprof_bam_resistances = collate_bam_resistance.outfile
-		Array[File?]? tbprof_fq_jsons        = qc_fastqs.tbprofiler_json
+		Array[File?]  tbprof_fq_jsons        = qc_fastqs.tbprofiler_json
 		File?         tbprof_fq_strains      = collate_fq_strains.outfile
-		Array[File?]? tbprof_fq_summaries    = qc_fastqs.tbprofiler_txt
+		Array[File?]  tbprof_fq_summaries    = qc_fastqs.tbprofiler_txt
 		File?         tbprof_fq_resistances  = collate_fq_resistance.outfile
-
+		
 		# tree nine
-		File? tree_nwk = trees.tree_nwk
-		File? tree_usher = trees.tree_usher_raw
-		File? tree_taxonium = trees.tree_taxonium
-		File? tree_nextstrain = trees.tree_nextstrain
+		File?        tree_nwk         = trees.tree_nwk
+		File?        tree_usher       = trees.tree_usher_raw
+		File?        tree_taxonium    = trees.tree_taxonium
+		File?        tree_nextstrain  = trees.tree_nextstrain
 		Array[File]? trees_nextstrain = trees.subtrees_nextstrain
 	}
 }

--- a/myco_raw.wdl
+++ b/myco_raw.wdl
@@ -6,7 +6,7 @@ import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.12/tasks/process
 import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.10/tree_nine.wdl" as build_treesWF
 import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.9/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.2.2/tbprofiler_tasks.wdl" as profiler
-import "https://raw.githubusercontent.com/aofarrel/TBfastProfiler/0.0.4/TBfastProfiler.wdl" as earlyQC
+import "https://raw.githubusercontent.com/aofarrel/TBfastProfiler/0.0.4/TBfastProfiler.wdl" as qc_fastqsWF # aka earlyQC
 
 workflow myco {
 	input {
@@ -91,7 +91,7 @@ workflow myco {
     		File real_decontaminated_fastq_2=select_first([decontam_each_sample.decontaminated_fastq_2, paired_fastqs[0]])
 
 			if(!early_qc_skip_entirely) {
-				call earlyQC.TBfastProfiler as qc_fastqs {
+				call qc_fastqsWF.TBfastProfiler as qc_fastqs {
 					input:
 						fastq1 = real_decontaminated_fastq_1,
 						fastq2 = real_decontaminated_fastq_2,

--- a/myco_raw.wdl
+++ b/myco_raw.wdl
@@ -1,7 +1,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.9.1/tasks/combined_decontamination.wdl" as clckwrk_combonation
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.9.1/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/main/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
 import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.12/tasks/processing_tasks.wdl" as sranwrp_processing
 import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.10/tree_nine.wdl" as build_treesWF
 import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.9/vcf_to_diff.wdl" as diff
@@ -163,13 +163,13 @@ workflow myco {
 	}
 
 	# do some wizardry to deal with optionals
-	Array[File] minos_vcfs_if_earlyQC_filtered = select_all(variant_call_after_earlyQC_filtering.vcf_final_call_set)
-	Array[File] minos_vcfs_if_earlyQC_but_not_filtering = select_all(variant_call_after_earlyQC_but_not_filtering_samples.vcf_final_call_set)
-	Array[File] minos_vcfs_if_no_earlyQC = select_all(variant_call_without_earlyQC.vcf_final_call_set)
+	Array[File] minos_vcfs_if_earlyQC_filtered = select_all(variant_call_after_earlyQC_filtering.adjudicated_vcf)
+	Array[File] minos_vcfs_if_earlyQC_but_not_filtering = select_all(variant_call_after_earlyQC_but_not_filtering_samples.adjudicated_vcf)
+	Array[File] minos_vcfs_if_no_earlyQC = select_all(variant_call_without_earlyQC.adjudicated_vcf)
 	
-	Array[File] bams_if_earlyQC_filtered = select_all(variant_call_after_earlyQC_filtering.mapped_to_ref)
-	Array[File] bams_if_earlyQC_but_not_filtering = select_all(variant_call_after_earlyQC_but_not_filtering_samples.mapped_to_ref)
-	Array[File] bams_if_no_earlyQC = select_all(variant_call_without_earlyQC.mapped_to_ref)
+	Array[File] bams_if_earlyQC_filtered = select_all(variant_call_after_earlyQC_filtering.bam)
+	Array[File] bams_if_earlyQC_but_not_filtering = select_all(variant_call_after_earlyQC_but_not_filtering_samples.bam)
+	Array[File] bams_if_no_earlyQC = select_all(variant_call_without_earlyQC.bam)
 	
 	Array[File] minos_vcfs = flatten([minos_vcfs_if_earlyQC_filtered, minos_vcfs_if_earlyQC_but_not_filtering, minos_vcfs_if_no_earlyQC])
 	Array[File] bams_to_ref = flatten([bams_if_earlyQC_filtered, bams_if_earlyQC_but_not_filtering, bams_if_no_earlyQC])

--- a/myco_raw.wdl
+++ b/myco_raw.wdl
@@ -16,7 +16,7 @@ workflow myco {
 		
 		# TODO: REPLACE WITH BETTER DEFAULTS
 		Float   covstats_qc_cutoff_coverages    =   10.00
-		Float   covstats_qc_cutoff_unmapped     =    0.10
+		Float   covstats_qc_cutoff_unmapped     =    2.00
 		Boolean covstats_qc_skip_entirely       = false
 		
 		Boolean diff_force                      = false

--- a/myco_raw.wdl
+++ b/myco_raw.wdl
@@ -7,7 +7,7 @@ import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.10/tree_nine.wd
 import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.9/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.2.2/tbprofiler_tasks.wdl" as profiler
 import "https://raw.githubusercontent.com/aofarrel/TBfastProfiler/main/TBfastProfiler.wdl" as qc_fastqsWF # aka earlyQC
-import "https://raw.githubusercontent.com/aofarrel/goleft-wdl/0.1.2/covstats.wdl" as covstatsWF
+import "https://raw.githubusercontent.com/aofarrel/goleft-wdl/0.1.2/goleft_functions.wdl" as goleft
 
 
 workflow myco {
@@ -211,14 +211,14 @@ workflow myco {
 		if(!covstats_qc_skip_entirely) {
 	
 			# covstats to check coverage and percent mapped to reference
-			call covstatsWF.Covstats as covstats {
+			call goleft.covstats as covstats {
 				input:
-					bamsOrCrams = [vcfs_and_bams.left[0]],
-					baisOrCrais = [vcfs_and_bams.left[1]]
+					inputBamOrCram = vcfs_and_bams.left[0],
+					allInputIndexes = [vcfs_and_bams.left[1]]
 			}
 			
-			if(covstats.percentUnmapped[0] > covstats_qc_cutoff_unmapped) {
-				if(covstats.coverages[0] > covstats_qc_cutoff_coverages) {
+			if(covstats.percentUnmapped > covstats_qc_cutoff_unmapped) {
+				if(covstats.coverage > covstats_qc_cutoff_coverages) {
 					
 					# make diff files
 					call diff.make_mask_and_diff as make_mask_and_diff_after_covstats {
@@ -331,7 +331,7 @@ workflow myco {
 		Array[File]  vcfs  = minos_vcfs
 		
 		# metadata
-		Array[File?]  covstats_reports       = covstats.covstatsReport
+		Array[File?]  covstats_reports       = covstats.covstatsOutfile
 		Array[File?]  diff_reports           = real_reports
 		Array[File?]  fastp_reports          = qc_fastqs.fastp_txt
 		File?         tbprof_bam_depths      = collate_bam_depth.outfile

--- a/myco_raw.wdl
+++ b/myco_raw.wdl
@@ -49,7 +49,7 @@ workflow myco {
 
 	parameter_meta {
 		covstats_qc_cutoff_coverages: "If covstats thinks coverage is below this, throw out this sample"
-		covstats_qc_cutoff_unmapped: "If covstats thinks this porportion (as float, 0.5 = 50%) of data does not map to H37Rv, throw out this sample"
+		covstats_qc_cutoff_unmapped: "If covstats thinks this porportion (as float, 50 = 50%) of data does not map to H37Rv, throw out this sample"
 		covstats_qc_skip_entirely: "Should we skip covstats entirely?"
 		diff_force: "If true and if decorate_tree is false, generate diff files. (Diff files will always be created if decorate_tree is true.)"
 		diff_mask_these_regions: "Bed file of regions to mask when making diff files"

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -73,10 +73,10 @@ workflow myco {
 		
 		tree_decoration: "Should usher, taxonium, and NextStrain trees be generated?"
 		tree_to_decorate: "Base tree to use if tree_decoration = true"
-		tree_max_low_coverage_sites: "If a diff file has higher than this percent (as float, eg 0.5 = 50%) bad data, do not include it in the tree"
+		tree_max_low_coverage_sites: "If a diff file has higher than this porportion (as float, eg 0.5 = 50%) bad data, do not include it in the tree"
 		
 		early_qc_apply_cutoffs: "If true, run fastp + TBProfiler on decontaminated fastqs and apply cutoffs to determine which samples should be thrown out."
-		early_qc_cutoff_q30: "Decontaminated samples with less than this percentage (as float, 0.5 = 50%) of reads above qual score of 30 will be discarded iff early_qc_apply_cutoffs is also true."
+		early_qc_cutoff_q30: "Decontaminated samples with less than this porportion (as float, 0.5 = 50%) of reads above qual score of 30 will be discarded iff early_qc_apply_cutoffs is also true."
 		early_qc_skip_entirely: "Do not run early QC (fastp + fastq-TBProfiler) at all. Does not affect whether or not TBProfiler is later run on bams. Overrides early_qc_apply_cutoffs."
 		fastqc_on_timeout: "If true, fastqc one read from a sample when decontamination or variant calling times out"
 		
@@ -87,9 +87,9 @@ workflow myco {
 		subsample_cutoff: "If a fastq file is larger than than size in MB, subsample it with seqtk (set to -1 to disable)"
 		subsample_seed: "Seed used for subsampling with seqtk"
 		
-		quick_tasks_disk_size: "Disk size (in GB) for tasks that process metadata. For absolutely massive runs this might be worth increasing for faster delocalization."
+		quick_tasks_disk_size: "Disk size in GB to use for quick file-processing tasks; increasing this might slightly speed up file localization"
 		
-		tbprofiler_on_bam: "If true, run TBProfiler on BAMs."
+		tbprofiler_on_bam: "If true, run TBProfiler on BAMs"
 		
 		timeout_decontam_part1: "Discard any sample that is still running in clockwork map_reads after this many minutes (set to 0 to never timeout)"
 		timeout_decontam_part2: "Discard any sample that is still running in clockwork rm_contam after this many minutes (set to 0 to never timeout)"

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -9,7 +9,7 @@ import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.9/vcf_to_diff.wd
 import "https://raw.githubusercontent.com/aofarrel/fastqc-wdl/0.0.2/fastqc.wdl" as fastqc
 import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.2.2/tbprofiler_tasks.wdl" as profiler
 import "https://raw.githubusercontent.com/aofarrel/TBfastProfiler/0.0.4/TBfastProfiler.wdl" as qc_fastqsWF # aka earlyQC
-import "https://raw.githubusercontent.com/aofarrel/goleft-wdl/small-improvements/covstats.wdl" as covstatsWF
+import "https://raw.githubusercontent.com/aofarrel/goleft-wdl/0.1.2/covstats.wdl" as covstatsWF
 
 
 workflow myco {
@@ -272,7 +272,6 @@ workflow myco {
 				input:
 					bamsOrCrams = [vcfs_and_bams.left[0]],
 					baisOrCrais = [vcfs_and_bams.left[1]]
-					
 			}
 			
 			if(covstats.percentUnmapped[0] > covstats_qc_cutoff_unmapped) {
@@ -288,7 +287,6 @@ workflow myco {
 							diffs = create_diff_files
 					}
 				}
-				
 			}
 		}
 		

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -8,7 +8,7 @@ import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.10/tree_nine.wd
 import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.9/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/fastqc-wdl/0.0.2/fastqc.wdl" as fastqc
 import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.2.2/tbprofiler_tasks.wdl" as profiler
-import "https://raw.githubusercontent.com/aofarrel/TBfastProfiler/main/TBfastProfiler.wdl" as qc_fastqsWF # aka earlyQC
+import "https://raw.githubusercontent.com/aofarrel/TBfastProfiler/0.0.5/TBfastProfiler.wdl" as qc_fastqsWF # aka earlyQC
 import "https://raw.githubusercontent.com/aofarrel/goleft-wdl/0.1.2/goleft_functions.wdl" as goleft
 
 

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -23,8 +23,8 @@ workflow myco {
 		Boolean variantcalling_crash_on_timeout = false
 		
 		# TODO: REPLACE WITH BETTER DEFAULTS
-		Float covstats_qc_cutoff_unmapped = 0.10
-		Float covstats_qc_cutoff_coverages = 0.10
+		Float covstats_qc_cutoff_unmapped = 10
+		Float covstats_qc_cutoff_coverages = 2
 		Boolean covstats_qc_skip_entirely = false
 		
 		# creation + masking of diff files


### PR DESCRIPTION
changes for users
* covstats has been implemented!
	* You can filter out samples that have too low coverage or too many unmapped reads
* bams and diff reports are now workflow-level outputs (why weren't they before???)
* The variant caller now outputs its bai files, not just its bams, and bais are a workflow-level output
* All variant caller runtime attributes are now workflow-level
* TBFastprofiler's fastp results now have unique filenames, which makes bulk download of them without them overwriting each other possible
* Some redundant input variables have been removed, such as the ref genome for tree building

changes for devs
* The scatter than is used to create diff files now uses a more complicated three-way scatter -- this *should not be an issue for any WDL executor or WDL backend* that properly implements the WDL spec, but it could break on executors that are off-spec (specifically ones that reorder arrays; our scatter relies on arrays maintaining their order). If you are reading this PR in the future wondering why something broke here, this might be the culprit!
	* I also updated clockwork-wdl to deal with this. As of 2.9.2 of clockwork-wdl, you have the option to output the bams and bais as a tarball. You can use that to recreate the simplier scatter of version 4.4.1 or earlier of myco. You will need to modify some tasks to untar things, of course.
* goleft is less messy now, so less shellcheck warnings
* docs aren't autogenerated anymore because that script was worse than maintaining the docs by hand 
