### PR TITLE
Filter bad diffs before tree nine

### DIFF
--- a/doc/inputs.md
+++ b/doc/inputs.md
@@ -39,17 +39,19 @@ myco_cleaned expects that the FASTQs you are putting into have already been clea
 | covstats_qc_cutoff_coverages | Float  | 10 | If covstats thinks coverage is below this, throw out this sample |  
 | covstats_qc_cutoff_unmapped | Float  | 2 | If covstats thinks this percentage (50 = 50%) of data does not map to H37Rv, throw out this sample |  
 | covstats_qc_skip_entirely | Boolean  | false | Should we avoid running covstats? Does not affect other forms of QC. |  
+| diff_max_low_cov_pct_per_sample | Float  | 0.05 | If more than this percent (0.5 = 50%) of a sample's sites get masked for being below `diff_min_coverage_per_site`, throw out the whole sample. |  
 | diff_min_coverage_per_site | Int  | 10 | Positions with coverage below this value will be masked in diff files |
 | early_qc_apply_cutoffs | Boolean  | false | If true, run fastp + TBProfiler on decontaminated fastqs and apply cutoffs to determine which samples should be thrown out. |  
 | early_qc_cutoff_q30 | Float  | 0.9 | Decontaminated samples with less than this percentage (as float, 0.5 = 50%) of reads above qual score of 30 will be discarded iff early_qc_apply_cutoffs is also true. |  
 | early_qc_skip_entirely | Boolean  | false | Do not run early QC (fastp + fastq-TBProfiler) at all. Does not affect whether or not TBProfiler is later run on bams. Overrides early_qc_apply_cutoffs. |  
 | fastqc_on_timeout | Boolean  | false | (myco_sra only) If true, fastqc one read from a sample when decontamination or variant calling times out |  
-| tree_max_low_coverage_sites | Float  | 0.05 | If a diff file has higher than this percent (0.5 = 50%) bad data, do not include it in the tree (irrelevant if tree_decoration is false) |  
 
-Note that diff_min_coverage_per_site works on a per-site basis. Other forms of QC will throw out entire samples, while this one is masking only particular regions in a sample.
+Note that all forms of QC will throw out entire samples, with two exceptions: 
+  * `diff_min_coverage_per_site` works on a per-site basis, masking individual sites below that value but not throwing out the entire sample (unless so many sites get masked that `diff_max_low_cov_pct_per_sample` kicks in)
+  * `fastqc_on_timeout` will run fastQC if true, but does not parse its output - the samples have already been discarded upstream when they timed out
   
 ## Timeouts  
-When working with data of unknown quality such as SRA data, it can be helpful to quickly remove samples that are likely low-quality. While developing myco on SRA data, we noticed that if a given sample took an unusually long time in the decontamination or variant calling step, they were likely to end up filtered out by the final quality control steps of the pipeline. This is especially true of the decontamination step -- the more contamination a sample has, the more that step has to do. This heuristic was defined on the default runtime attributes and using Terra as a backend, so straying from those defaults is likely to make the default timeout values less useful. This *includes* changing from SDDs to HDDs! 
+When working with data of unknown quality, it can be helpful to quickly remove samples that are likely low-quality. While developing myco on SRA data, we noticed that if a given sample took an unusually long time in the decontamination or variant calling step, they were likely to end up filtered out by the final quality control steps of the pipeline. This is especially true of the decontamination step -- the more contamination a sample has, the more that step has to do. This heuristic was defined on the default runtime attributes and using Terra as a backend, so straying from those defaults is likely to make the default timeout values less useful. This *includes* changing from SDDs to HDDs! 
   
 | name | type | myco_sra default | description |  
 |:---:|:---:|:---:|:---:|  

--- a/myco_raw.wdl
+++ b/myco_raw.wdl
@@ -4,7 +4,7 @@ import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.9.1/tasks/com
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.9.2/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
 import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.12/tasks/processing_tasks.wdl" as sranwrp_processing
 import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.10/tree_nine.wdl" as build_treesWF
-import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.1.9/vcf_to_diff.wdl" as diff
+import "https://raw.githubusercontent.com/aofarrel/parsevcf/throw-out-bad-samples/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.2.2/tbprofiler_tasks.wdl" as profiler
 import "https://raw.githubusercontent.com/aofarrel/TBfastProfiler/0.0.6/TBfastProfiler.wdl" as qc_fastqsWF # aka earlyQC
 import "https://raw.githubusercontent.com/aofarrel/goleft-wdl/0.1.2/goleft_functions.wdl" as goleft
@@ -19,9 +19,9 @@ workflow myco {
 		Float   covstats_qc_cutoff_unmapped     =    2.00
 		Boolean covstats_qc_skip_entirely       = false
 		
-		Boolean diff_force                      = false
 		File?   diff_mask_these_regions
-		Int     diff_min_coverage_per_site      =   10
+		Int     diff_min_cov_per_site           =   10
+		Float   diff_min_cov_ratio_per_sample   =    0.20
 		Boolean early_qc_apply_cutoffs          = false
 		Float   early_qc_cutoff_q30             =    0.90
 		Boolean early_qc_skip_entirely          = false
@@ -51,9 +51,9 @@ workflow myco {
 		covstats_qc_cutoff_coverages: "If covstats thinks coverage is below this, throw out this sample"
 		covstats_qc_cutoff_unmapped: "If covstats thinks this porportion (as float, 50 = 50%) of data does not map to H37Rv, throw out this sample"
 		covstats_qc_skip_entirely: "Should we skip covstats entirely?"
-		diff_force: "If true and if decorate_tree is false, generate diff files. (Diff files will always be created if decorate_tree is true.)"
 		diff_mask_these_regions: "Bed file of regions to mask when making diff files"
-		diff_min_coverage_per_site: "Positions with coverage below this value will be masked in diff files"
+		diff_min_cov_per_site: "Positions with coverage below this value will be masked in diff files"
+		diff_min_cov_ratio_per_sample: "amples who have more than this porportion (as float, 0.5 = 50%) of positions below diff_min_coverage_per_site will be discarded"
 		early_qc_apply_cutoffs: "If true, run fastp + TBProfiler on decontaminated fastqs and apply cutoffs to determine which samples should be thrown out."
 		early_qc_cutoff_q30: "Decontaminated samples with less than this porportion (as float, 0.5 = 50%) of reads above qual score of 30 will be discarded iff early_qc_apply_cutoffs is also true."
 		early_qc_skip_entirely: "Do not run early QC (fastp + fastq-TBProfiler) at all. Does not affect whether or not TBProfiler is later run on bams. Overrides early_qc_apply_cutoffs."
@@ -67,20 +67,8 @@ workflow myco {
 		timeout_decontam_part2: "Discard any sample that is still running in clockwork rm_contam after this many minutes (set to 0 to never timeout)"
 		timeout_variant_caller: "Discard any sample that is still running in clockwork variant_call_one_sample after this many minutes (set to 0 to never timeout)"
 		tree_decoration: "Should usher, taxonium, and NextStrain trees be generated?"
-		tree_max_low_coverage_sites: "If a diff file has higher than this porportion (0.5 = 50%) bad data, do not include it in the tree"
 		tree_to_decorate: "Base tree to use if tree_decoration = true"
 	}
-
-	# WDL doesn't understand mutual exclusivity, so we have to get a little creative on 
-	# our determination of whether or not we want to create diff files.
-	if(tree_decoration)  {  Boolean create_diff_files_   = true  }
-	if(!tree_decoration) {
-		if(!tree_decoration){  Boolean create_diff_files__  = false }
-		if(tree_decoration) {  Boolean create_diff_files___ = true  }
-	}
-	Boolean create_diff_files = select_first([create_diff_files_,
-											  create_diff_files__, 
-											  create_diff_files___])
 
 	scatter(paired_fastqs in paired_fastq_sets) {
 		call clckwrk_combonation.combined_decontamination_single_ref_included as decontam_each_sample {
@@ -225,9 +213,9 @@ workflow myco {
 						input:
 							bam = vcfs_and_bams.left[0],
 							vcf = vcfs_and_bams.right,
-							min_coverage_per_site = diff_min_coverage_per_site,
+							min_coverage_per_site = diff_min_cov_per_site,
 							tbmf = diff_mask_these_regions,
-							diffs = create_diff_files
+							discard_sample_if_more_than_this_percent_is_low_coverage = diff_min_cov_ratio_per_sample
 					}
 				}
 			}
@@ -240,9 +228,9 @@ workflow myco {
 				input:
 					bam = vcfs_and_bams.left[0],
 					vcf = vcfs_and_bams.right,
-					min_coverage_per_site = diff_min_coverage_per_site,
+					min_coverage_per_site = diff_min_cov_per_site,
 					tbmf = diff_mask_these_regions,
-					diffs = create_diff_files
+					discard_sample_if_more_than_this_percent_is_low_coverage = diff_min_cov_ratio_per_sample
 			}
 		}
 		

--- a/myco_raw.wdl
+++ b/myco_raw.wdl
@@ -20,8 +20,8 @@ workflow myco {
 		Boolean covstats_qc_skip_entirely       = false
 		
 		File?   diff_mask_these_regions
+		Float   diff_max_low_cov_pct_per_sample =    0.20
 		Int     diff_min_cov_per_site           =   10
-		Float   diff_min_cov_ratio_per_sample   =    0.20
 		Boolean early_qc_apply_cutoffs          = false
 		Float   early_qc_cutoff_q30             =    0.90
 		Boolean early_qc_skip_entirely          = false
@@ -33,7 +33,6 @@ workflow myco {
 		Int     timeout_decontam_part2          =    0
 		Int     timeout_variant_caller          =    0
 		Boolean tree_decoration                 = false
-		Float   tree_max_low_coverage_sites     =    0.05
 		File?   tree_to_decorate
 		Int     variantcalling_addl_disk        =  100
 		Boolean variantcalling_crash_on_error   = false
@@ -52,8 +51,8 @@ workflow myco {
 		covstats_qc_cutoff_unmapped: "If covstats thinks this proportion (as float, 50 = 50%) of data does not map to H37Rv, throw out this sample"
 		covstats_qc_skip_entirely: "Should we skip covstats entirely?"
 		diff_mask_these_regions: "Bed file of regions to mask when making diff files"
+		diff_max_low_cov_pct_per_sample: "Samples who have more than this proportion (as float, 0.5 = 50%) of positions below diff_min_coverage_per_site will be discarded"
 		diff_min_cov_per_site: "Positions with coverage below this value will be masked in diff files"
-		diff_min_cov_ratio_per_sample: "Samples who have more than this proportion (as float, 0.5 = 50%) of positions below diff_min_coverage_per_site will be discarded"
 		early_qc_apply_cutoffs: "If true, run fastp + TBProfiler on decontaminated fastqs and apply cutoffs to determine which samples should be thrown out."
 		early_qc_cutoff_q30: "Decontaminated samples with less than this proportion (as float, 0.5 = 50%) of reads above qual score of 30 will be discarded iff early_qc_apply_cutoffs is also true."
 		early_qc_skip_entirely: "Do not run early QC (fastp + fastq-TBProfiler) at all. Does not affect whether or not TBProfiler is later run on bams. Overrides early_qc_apply_cutoffs."
@@ -215,7 +214,7 @@ workflow myco {
 							vcf = vcfs_and_bams.right,
 							min_coverage_per_site = diff_min_cov_per_site,
 							tbmf = diff_mask_these_regions,
-							max_ratio_low_coverage_sites_per_sample = diff_min_cov_ratio_per_sample
+							max_ratio_low_coverage_sites_per_sample = diff_max_low_cov_pct_per_sample
 					}
 				}
 			}
@@ -230,7 +229,7 @@ workflow myco {
 					vcf = vcfs_and_bams.right,
 					min_coverage_per_site = diff_min_cov_per_site,
 					tbmf = diff_mask_these_regions,
-					max_ratio_low_coverage_sites_per_sample = diff_min_cov_ratio_per_sample
+					max_ratio_low_coverage_sites_per_sample = diff_max_low_cov_pct_per_sample
 			}
 		}
 		
@@ -306,8 +305,7 @@ workflow myco {
 				input:
 					diffs = coerced_diffs,
 					input_tree = tree_to_decorate,
-					coverage_reports = coerced_reports,
-					max_low_coverage_sites = tree_max_low_coverage_sites
+					coverage_reports = coerced_reports
 			}
 		}
 	}

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -26,7 +26,7 @@ workflow myco {
 		# creation + masking of diff files
 		Int     diff_min_cov_per_site         = 10
 		File?   diff_mask_these_regions
-		Float   diff_min_cov_ratio_per_sample = 0.05
+		Float   diff_max_low_cov_pct_per_sample = 0.05
 		
 		# QC
 		Boolean fastqc_on_timeout       = false
@@ -78,7 +78,7 @@ workflow myco {
 		force_diff: "Make a diff file even if sample fails diff_min_coverage_ratio_per_sample (will not create diff if any other QC fails)"
 		diff_mask_these_regions: "Bed file of regions to mask when making diff files"
 		diff_min_coverage_per_site: "Positions with coverage below this value will be masked in diff files"
-		diff_min_coverage_ratio_per_sample: "Samples who have more than this proportion (as float, 0.5 = 50%) of positions below diff_min_coverage_per_site will be discarded"
+		diff_max_low_cov_pct_per_sample: "Samples who have more than this proportion (as float, 0.5 = 50%) of positions below diff_min_coverage_per_site will be discarded"
 		subsample_cutoff: "If a fastq file is larger than than size in MB, subsample it with seqtk (set to -1 to disable)"
 		subsample_seed: "Seed used for subsampling with seqtk"
 		
@@ -278,7 +278,7 @@ workflow myco {
 							vcf = vcfs_and_bams.right,
 							min_coverage_per_site = diff_min_cov_per_site,
 							tbmf = diff_mask_these_regions,
-							max_ratio_low_coverage_sites_per_sample = diff_min_cov_ratio_per_sample
+							max_ratio_low_coverage_sites_per_sample = diff_max_low_cov_pct_per_sample
 					}
 				}
 			}
@@ -293,7 +293,7 @@ workflow myco {
 					vcf = vcfs_and_bams.right,
 					min_coverage_per_site = diff_min_cov_per_site,
 					tbmf = diff_mask_these_regions,
-					max_ratio_low_coverage_sites_per_sample = diff_min_cov_ratio_per_sample
+					max_ratio_low_coverage_sites_per_sample = diff_max_low_cov_pct_per_sample
 			}
 		}
 		

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -77,7 +77,7 @@ workflow myco {
 		early_qc_cutoff_q30: "Decontaminated samples with less than this porportion (as float, 0.5 = 50%) of reads above qual score of 30 will be discarded iff early_qc_apply_cutoffs is also true."
 		early_qc_skip_entirely: "Do not run early QC (fastp + fastq-TBProfiler) at all. Does not affect whether or not TBProfiler is later run on bams. Overrides early_qc_apply_cutoffs."
 		fastqc_on_timeout: "If true, fastqc one read from a sample when decontamination or variant calling times out"
-		
+		force_diff: "Make a diff file even if sample fails diff_min_coverage_ratio_per_sample (will not create diff if any other QC fails)"
 		diff_mask_these_regions: "Bed file of regions to mask when making diff files"
 		diff_min_coverage_per_site: "Positions with coverage below this value will be masked in diff files"
 		diff_min_coverage_ratio_per_sample: "Samples who have more than this porportion (as float, 0.5 = 50%) of positions below diff_min_coverage_per_site will be discarded"
@@ -280,7 +280,7 @@ workflow myco {
 							vcf = vcfs_and_bams.right,
 							min_coverage_per_site = diff_min_cov_per_site,
 							tbmf = diff_mask_these_regions,
-							discard_sample_if_more_than_this_percent_is_low_coverage = diff_min_cov_ratio_per_sample
+							min_porportion_low_coverage_per_sample = diff_min_cov_ratio_per_sample
 					}
 				}
 			}
@@ -295,7 +295,7 @@ workflow myco {
 					vcf = vcfs_and_bams.right,
 					min_coverage_per_site = diff_min_cov_per_site,
 					tbmf = diff_mask_these_regions,
-					discard_sample_if_more_than_this_percent_is_low_coverage = diff_min_cov_ratio_per_sample
+					min_porportion_low_coverage_per_sample = diff_min_cov_ratio_per_sample
 			}
 		}
 		

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -28,9 +28,9 @@ workflow myco {
 		Boolean covstats_qc_skip_entirely = false
 		
 		# creation + masking of diff files
-		Int     diff_min_coverage_per_site         = 10
+		Int     diff_min_cov_per_site         = 10
 		File?   diff_mask_these_regions
-		Float   diff_min_coverage_ratio_per_sample = 0.05
+		Float   diff_min_cov_ratio_per_sample = 0.05
 		
 		# QC
 		Boolean fastqc_on_timeout       = false
@@ -278,9 +278,9 @@ workflow myco {
 						input:
 							bam = vcfs_and_bams.left[0],
 							vcf = vcfs_and_bams.right,
-							min_coverage_per_site = diff_min_coverage_per_site,
+							min_coverage_per_site = diff_min_cov_per_site,
 							tbmf = diff_mask_these_regions,
-							discard_sample_if_more_than_this_percent_is_low_coverage = diff_min_coverage_ratio_per_sample
+							discard_sample_if_more_than_this_percent_is_low_coverage = diff_min_cov_ratio_per_sample
 					}
 				}
 			}
@@ -293,9 +293,9 @@ workflow myco {
 				input:
 					bam = vcfs_and_bams.left[0],
 					vcf = vcfs_and_bams.right,
-					min_coverage_per_site = diff_min_coverage_per_site,
+					min_coverage_per_site = diff_min_cov_per_site,
 					tbmf = diff_mask_these_regions,
-					discard_sample_if_more_than_this_percent_is_low_coverage = diff_min_coverage_ratio_per_sample
+					discard_sample_if_more_than_this_percent_is_low_coverage = diff_min_cov_ratio_per_sample
 			}
 		}
 		


### PR DESCRIPTION
Brings over changes from https://github.com/aofarrel/parsevcf/pull/4 to myco_raw and myco_sra to allow for filtering out low coverage samples before Tree Nine.