### PR TITLE
QC report file now has sample name

### DIFF
--- a/myco_raw.wdl
+++ b/myco_raw.wdl
@@ -473,7 +473,8 @@ workflow myco {
 	call sranwrp_processing.map_to_tsv_or_csv as qc_summary {
 		input:
 			the_map = metrics_to_values,
-			column_names = if length(paired_fastq_sets) == 1 then [basename(paired_fastq_sets[0][0])] else ["sample"]
+			column_names = if length(paired_fastq_sets) == 1 then [basename(paired_fastq_sets[0][0])] else ["sample"],
+			outfile = if length(paired_fastq_sets) == 1 then basename(paired_fastq_sets[0][0])+"_qc" else "combined_qc_report.txt"
 	}
 		
 	output {

--- a/myco_raw.wdl
+++ b/myco_raw.wdl
@@ -6,7 +6,7 @@ import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.17/tasks/process
 import "https://raw.githubusercontent.com/aofarrel/tree_nine/0.0.11/tree_nine.wdl" as build_treesWF
 import "https://raw.githubusercontent.com/aofarrel/parsevcf/1.2.0/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.2.2/tbprofiler_tasks.wdl" as profiler
-import "https://raw.githubusercontent.com/aofarrel/TBfastProfiler/0.0.11/neoTBfastProfiler.wdl" as qc_fastqsWF # aka earlyQC
+import "https://raw.githubusercontent.com/aofarrel/TBfastProfiler/0.0.12/neoTBfastProfiler.wdl" as qc_fastqsWF # aka earlyQC
 import "https://raw.githubusercontent.com/aofarrel/goleft-wdl/0.1.2/goleft_functions.wdl" as goleft
 
 workflow myco {


### PR DESCRIPTION
More improvements to the sample name determination need to be done, but at least everything isn't called "something" anymore.

TODO: check this does not break when running on more than one sample (in progress)