### PR TITLE
Alternative method for allowing string inputs into myco_sra

### DIFF
--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -27,6 +27,8 @@ import "https://raw.githubusercontent.com/aofarrel/goleft-wdl/0.1.3/goleft_funct
 
 workflow myco {
 	input {
+		# Terra users -- these will unfortunately not sort to the top anymore, you may need to
+		# search to find these options on Terra's workflow submission UI
 		File? biosample_accessions
 		Array[String]? biosample_accessions_as_array
 

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -3,7 +3,7 @@ version 1.0
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.16.8/tasks/combined_decontamination.wdl" as clckwrk_combonation
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/2.16.5/tasks/variant_call_one_sample.wdl" as clckwrk_var_call
 import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.24/tasks/pull_fastqs.wdl" as sranwrp_pull
-import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.24/tasks/processing_tasks.wdl" as sranwrp_processing
+import "https://raw.githubusercontent.com/aofarrel/SRANWRP/v1.1.29/tasks/processing_tasks.wdl" as sranwrp_processing
 import "https://raw.githubusercontent.com/aofarrel/vcf_to_diff_wdl/0.0.3/vcf_to_diff.wdl" as diff
 import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.3.0/tbprofiler_tasks.wdl" as profiler
 import "https://raw.githubusercontent.com/aofarrel/tb_profiler/0.3.0/theiagen_tbprofiler.wdl" as tbprofilerFQ_WF # fka earlyQC

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -27,7 +27,8 @@ import "https://raw.githubusercontent.com/aofarrel/goleft-wdl/0.1.3/goleft_funct
 
 workflow myco {
 	input {
-		File biosample_accessions
+		File? biosample_accessions
+		Array[String]? biosample_accessions_as_array
 
 		Boolean just_like_2024                 = false
 		Int     clean_average_q_score          = 29
@@ -51,7 +52,9 @@ workflow myco {
 	}
 
 	parameter_meta {
-		biosample_accessions: "File of BioSample accessions to pull, one accession per line"
+		# You MUST provide one of these
+		biosample_accessions: "File of BioSample accessions to pull, one accession per line (will be ignored if biosample_accessions_as_array also defined)"
+		biosample_accessions_as_array: "String array of BioSample accessions to pull (designed for Terra data tables)"
 
 		clean_average_q_score: "Trim reads with an average quality score below this value. Independent of QC_min_q30."
 		covstatsQC_skip_entirely: "Should we skip covstats entirely?"
@@ -73,8 +76,9 @@ workflow myco {
 	Float QC_max_pct_low_coverage_sites_float = QC_max_pct_low_coverage_sites / 100.0
 	Int guardrail_subsample_cutoff = if guardrail_mode then 30000 else -1 # overridden by subsample_cutoff
 
-	call sranwrp_processing.extract_accessions_from_file as get_sample_IDs {
+	call sranwrp_processing.extract_accessions_from_file_or_string as get_sample_IDs {
 		input:
+			accessions_array = biosample_accessions_as_array,
 			accessions_file = biosample_accessions,
 			filter_na = true
 	}

--- a/myco_sra.wdl
+++ b/myco_sra.wdl
@@ -229,6 +229,28 @@ workflow myco {
 	Array[File] real_reports = flatten([select_all(make_mask_and_diff_after_covstats.report), select_all(make_mask_and_diff_no_covstats.report)])
 	Array[File] real_masks = flatten([select_all(make_mask_and_diff_after_covstats.mask_file), select_all(make_mask_and_diff_no_covstats.mask_file)])
 
+	#########################################
+	#      TBProfiler metadata handling     #
+	#########################################
+	# This next section follows this line of logic:
+	# 1. Coerce TBProfiler's optional outputs into required types
+	# ---> This prevents certain WDL crashes and, somehow, doesn't crash even if the files don't exist
+	#      at runtime.
+	# 2. Determine if we ran TBProfiler on bams/FQs
+	# ---> Ideally we would know if TBProfiler ran on bams (which as a task is called profile_bam) by checking
+	#      if one of the outputs of profile_bam is defined(). However, for some bloody reason (see my comments
+	#      elsewhere about "SOTHWO", even if profile_bam didn't run, defined(profile_bam.strain) is always true!
+	#      This seems to be a result of Cromwell creating empty arrays for all possible outputs within a scatter(),
+	#      so the array itself is defined, it just has no values. Now, WHY Cromwell would premake empty arrays for
+	#      tasks that will never run is beyond me... but it does (at least it did in 2023; even if this behavior has
+	#      since changed that would mean I couldn't rely upon defined() not chaging b/n versions.)
+	# ---> As a workaround, we check if the metadata we coerced in #1 is an array of a non-zero length.
+	# ---> Can't we just check if length(profile_bam.sample_and_strain), ie the non-coerced version, has a non-zero
+	#      length? Maybe. IIRC there is a miniwdl/Cromwell inconsistency so don't do that unless something breaks.
+	# 3. Determine if we are running on one sample or multiple samples
+	# ---> If we are running on multiple samples it is worth our time concatenating a bunch of lists into one
+	#      metadata file. If we are running on just one sample this is not worth the compute cost/time.
+
 	# pull TBProfiler information, if we ran TBProfiler on bams
 	
 	# coerce optional types into required types (doesn't crash even if profile_bam didn't run)


### PR DESCRIPTION
rejecting this approach for a few reasons
* Terra sorts workflow inputs such that required inputs are on the top and everything is alphabetical by task name. Why workflow inputs aren't at top, I have no idea. Since I expose runtime attributes for most tasks, there are a ton of extraneous variables that show up before workflow variables. In other words, no required inputs --> user has to scroll a bunch to find the input they actually need
* This approach allowed for a string array of BioSamples. In truth, if you're running on Terra, you're going to want to run each sample as its own workflow using a data table such that each row (ie each workflow) gets a single BioSample.
* It's a bit too footgunny

I might reuse the generate_download_report_file logic though as a download report for single-string input is a bit silly.